### PR TITLE
test: Ensure tests run safely on live servers

### DIFF
--- a/service/database.py
+++ b/service/database.py
@@ -91,10 +91,17 @@ class Database(object):
         11: add_devices_use_sandbox,
     }
 
-    def __init__(self, database_url=None):
+    def __init__(self, database_url=None, readonly=False):
+
         if database_url is None:
             database_url = os.environ['DATABASE_URL']
+
         self.connection = psycopg2.connect(database_url)
+        self.connection.set_session(readonly=readonly)
+
+        # Migrations are disabled on readonly connections.
+        if readonly:
+            return
 
         # Create the metadata table (used for versioning).
         with Transaction(self.connection) as cursor:


### PR DESCRIPTION
This change ensures the tests can be run safely on staging and production instances of the StatusPanel service and adds a drive-by fix to guard against unexpected error responses for large file uploads (see https://github.com/jbmorley/statuspanel/issues/75).