### PR TITLE
ci: Support builds under Xcode 12.5.1

### DIFF
--- a/ios/StatusPanel/AppDelegate.swift
+++ b/ios/StatusPanel/AppDelegate.swift
@@ -34,7 +34,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         client = Client(baseUrl: "https://statuspanel.io/")
 
-        let configuration = try! Bundle.main.getConfiguration()
+        let configuration = try! Bundle.main.configuration()
         sourceController.add(dataSource:TFLDataSource(configuration: configuration))
         sourceController.add(dataSource:NationalRailDataSource(configuration: configuration))
         sourceController.add(dataSource:CalendarSource())

--- a/ios/StatusPanel/Extensions/Bundle.swift
+++ b/ios/StatusPanel/Extensions/Bundle.swift
@@ -22,7 +22,7 @@ import Foundation
 
 extension Bundle {
 
-    func getConfiguration() throws -> Configuration {
+    func configuration() throws -> Configuration {
         guard let url = Bundle.main.url(forResource: "configuration", withExtension: "json") else {
             throw StatusPanelError.missingConfiguration
         }


### PR DESCRIPTION
Where apparently `get throws { ... }` is not a valid construct. Swift
5.3 versus 5.5 in the Xcode 13 beta?

Instead, make it a simple function.