### PR TITLE
feat(ios): Use the new StatusPanel service URL

### DIFF
--- a/ios/StatusPanel/AppDelegate.swift
+++ b/ios/StatusPanel/AppDelegate.swift
@@ -30,9 +30,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var apnsToken: Data?
     var client: Client!
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication,
+                     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 
-        client = Client(baseUrl: "https://statuspanel.io/")
+        client = Client(baseUrl: "https://api.statuspanel.io/")
 
         let configuration = try! Bundle.main.configuration()
         sourceController.add(dataSource:TFLDataSource(configuration: configuration))

--- a/ios/StatusPanel/ViewController.swift
+++ b/ios/StatusPanel/ViewController.swift
@@ -387,7 +387,7 @@ class ViewController: UIViewController, SettingsViewControllerDelegate {
             encryptedParts.append(Data(encryptedDataBytes!))
         }
         let encryptedData = makeMultipartUpload(parts: encryptedParts)
-        let path = "https://statuspanel.io/api/v2/\(deviceid)"
+        let path = "https://api.statuspanel.io/api/v2/\(deviceid)"
         guard let url = URL(string: path) else {
             print("Unable to create URL")
             completion(false)


### PR DESCRIPTION
This change updates the iOS app to use the new https://api.statuspanel.io service URL.

It also includes a drive-by line length fix.