### PR TITLE
fix(ios): Use title case for the tube line names

### DIFF
--- a/ios/StatusPanel/StatusPanelError.swift
+++ b/ios/StatusPanel/StatusPanelError.swift
@@ -22,4 +22,5 @@ import Foundation
 
 enum StatusPanelError: Error {
     case missingConfiguration
+    case invalidResponse(String)
 }


### PR DESCRIPTION
This updates the code to use the built-in names for the tube lines which have been updated to include 'Line' so that the names are now explicitly all title cased. This means that the lines are always consistently named in the data source picker and on StatusPanel.