### PR TITLE
fix(ios): Verticial divider respects the height of the heading font

### DIFF
--- a/ios/StatusPanel/ViewController.swift
+++ b/ios/StatusPanel/ViewController.swift
@@ -29,9 +29,9 @@ class ViewController: UIViewController, SettingsViewControllerDelegate {
         case horizontal(originY: CGFloat)
     }
 
-    static let panelWidth = 640.0
-    static let panelHeight = 384.0
-    static let panelStatusBarHeight = 20.0
+    static let panelWidth: CGFloat = 640.0
+    static let panelHeight: CGFloat = 384.0
+    static let panelStatusBarHeight: CGFloat = 20.0
 
     @IBOutlet weak var imageView: UIImageView!
     @IBOutlet weak var redactButton: UIBarButtonItem!


### PR DESCRIPTION
This change makes the render state pertaining to the divider more explicit by introducing an `DividerStyle` enum with associated types for tracking both the divider orientation and position. It also introduces a drive-by fix to make the naming of the panel dimensions more idiomatic (dropping the `k` prefix), and pulls the status bar height out into a constant.