### PR TITLE
refactor(ios): Rename `LabelType` to `LabelStyle`

### DIFF
--- a/ios/StatusPanel/View Controllers/PrivacyModeController.swift
+++ b/ios/StatusPanel/View Controllers/PrivacyModeController.swift
@@ -85,7 +85,7 @@ class PrivacyModeController : UITableViewController, UINavigationControllerDeleg
         if indexPath.row < 2 {
             let frame = cell.contentView.bounds.insetBy(dx: cell.separatorInset.left, dy: 0)
             let redactMode: RedactMode = (indexPath.row == 0) ? .redactLines : .redactWords
-            let label = ViewController.getLabel(frame: frame, font: Config().font, redactMode: redactMode)
+            let label = ViewController.getLabel(frame: frame, font: Config().font, style: .text, redactMode: redactMode)
             label.text = "Redact text good"
             label.sizeToFit()
             label.frame = label.frame.offsetBy(dx: 0, dy: (frame.height - label.bounds.height) / 2)

--- a/ios/StatusPanel/View Controllers/SettingsViewController.swift
+++ b/ios/StatusPanel/View Controllers/SettingsViewController.swift
@@ -253,7 +253,7 @@ class SettingsViewController: UITableViewController, UIAdaptivePresentationContr
             let font = config.availableFonts[indexPath.row]
             let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
             let frame = cell.contentView.bounds.insetBy(dx: cell.separatorInset.left, dy: 0)
-            let label = ViewController.getLabel(frame:frame, font: font.configName)
+            let label = ViewController.getLabel(frame:frame, font: font.configName, style: .text)
             label.text = font.humanReadableName
             label.sizeToFit()
             label.frame = label.frame.offsetBy(dx: 30, dy: (frame.height - label.bounds.height) / 2)


### PR DESCRIPTION
Rename to `LablelStyle` to try to bring it inline with common naming conventions. This change also makes the style a required property of the `getLabel` method to make it more explicit what style is being requested at the call sites.