### PR TITLE
refactor(ios): Use `DataItemFlags.prefersEmptyColumn` to express column wrapping preference

### DIFF
--- a/ios/StatusPanel/Data/Calendar/CalendarSource.swift
+++ b/ios/StatusPanel/Data/Calendar/CalendarSource.swift
@@ -138,8 +138,8 @@ class CalendarSource : DataSource {
         let pred = eventStore.predicateForEvents(withStart: dayStart, end: dayEnd, calendars: calendars)
         let events = eventStore.events(matching: pred)
         var results = [DataItemBase]()
-        if (header != nil) {
-            results.append(DataItem(self.header!, flags: [.header]))
+        if let header = header {
+            results.append(DataItem(header, flags: [.prefersEmptyColumn]))
         }
 
         let config = Config()

--- a/ios/StatusPanel/ViewController.swift
+++ b/ios/StatusPanel/ViewController.swift
@@ -22,6 +22,18 @@ import UIKit
 import EventKit
 import Sodium
 
+
+extension DataItemFlags {
+
+    var style: ViewController.LabelStyle {
+        if contains(.header) {
+            return .header
+        }
+        return .text
+    }
+
+}
+
 class ViewController: UIViewController, SettingsViewControllerDelegate {
 
     enum DividerStyle {
@@ -219,6 +231,7 @@ class ViewController: UIViewController, SettingsViewControllerDelegate {
         let itemGap : CGFloat = 10
         var colStart = y
         var col = 1
+        var columnItemCount = 0 // Number of items assigned to the current column
         var divider: DividerStyle? = twoCols ? .vertical(originY: 0) : nil
         let redactMode: RedactMode = (shouldRedact ? (config.privacyMode == .redactWords ? .redactWords : .redactLines) : .none)
 
@@ -235,7 +248,7 @@ class ViewController: UIViewController, SettingsViewControllerDelegate {
             if prefix != "" {
                 let prefixLabel = ViewController.getLabel(frame: textFrame,
                                                           font: config.font,
-                                                          style: isFirstItemAndHeader ? .header : .text,
+                                                          style: flags.style,
                                                           redactMode: redactMode)
                 prefixLabel.textColor = foregroundColor
                 prefixLabel.numberOfLines = numPrefixLines
@@ -254,7 +267,7 @@ class ViewController: UIViewController, SettingsViewControllerDelegate {
             }
             let label = ViewController.getLabel(frame: textFrame,
                                                 font: config.font,
-                                                style: isFirstItemAndHeader ? .header : .text,
+                                                style: flags.style,
                                                 redactMode: redactMode)
             label.numberOfLines = 1 // Temporarily while we're using it in checkFit
 
@@ -292,10 +305,11 @@ class ViewController: UIViewController, SettingsViewControllerDelegate {
             }
             let sz = view.frame
             // Enough space for this item?
-            let itemIsColBreak = i != 0 && flags.contains(.header)
+            let itemIsColBreak = (columnItemCount > 0 && flags.contains(.prefersEmptyColumn))
             if (col == 1 && twoCols && (sz.height > maxy - y || itemIsColBreak)) {
                 // overflow to 2nd column
                 col += 1
+                columnItemCount = 0
                 x += midx + 5
                 y = colStart
                 view.frame = CGRect(x: x, y: y, width: sz.width, height: sz.height)
@@ -314,6 +328,11 @@ class ViewController: UIViewController, SettingsViewControllerDelegate {
             if isFirstItemAndHeader {
                 divider = .vertical(originY: y)
                 colStart = y
+            }
+
+            // Track the number of items in the current column.
+            if !isFirstItemAndHeader {
+                columnItemCount += 1
             }
 
         }


### PR DESCRIPTION
This change goes some way to making the layout more explicit by no longer using the condition that a header is not the first item as an indication that content should wrap to another column. Instead, it makes this explicit by using the `.prefersEmptyColumn` flag. This way, non-header items can also request a new column, and the `.header` flag can simply be used to determine the style. The change also introduces a new layout variable (`columnItemCount`) for tracking the number of items in the current column and uses this to determine whether a column wrap is actually necessary.