### PR TITLE
refactor(ios): Introduce a `DataItemFlags.spansColumns` flag for full-width items

### DIFF
--- a/ios/StatusPanel/Data/Calendar/CalendarSource.swift
+++ b/ios/StatusPanel/Data/Calendar/CalendarSource.swift
@@ -48,7 +48,7 @@ class CalendarHeader : DataItemBase {
     }
 
     func getFlags() -> DataItemFlags {
-        return [.header]
+        return [.header, .spansColumns]
     }
 
     let date: Date

--- a/ios/StatusPanel/Data/DataSource.swift
+++ b/ios/StatusPanel/Data/DataSource.swift
@@ -32,6 +32,7 @@ struct DataItemFlags: OptionSet {
     static let warning = DataItemFlags(rawValue: 1 << 0)
     static let header = DataItemFlags(rawValue: 1 << 1)
     static let prefersEmptyColumn = DataItemFlags(rawValue: 1 << 2)
+    static let spansColumns = DataItemFlags(rawValue: 1 << 3)
 }
 
 protocol DataItemBase : AnyObject {

--- a/ios/StatusPanel/ViewController.swift
+++ b/ios/StatusPanel/ViewController.swift
@@ -230,15 +230,14 @@ class ViewController: UIViewController, SettingsViewControllerDelegate {
         let colWidth = twoCols ? (rect.width / 2 - x * 2) : rect.width - x
         let itemGap : CGFloat = 10
         var colStart = y
-        var col = 1
+        var col = 0
         var columnItemCount = 0 // Number of items assigned to the current column
         var divider: DividerStyle? = twoCols ? .vertical(originY: 0) : nil
         let redactMode: RedactMode = (shouldRedact ? (config.privacyMode == .redactWords ? .redactWords : .redactLines) : .none)
 
-        for (i, item) in data.enumerated() {
+        for item in data {
             let flags = item.getFlags()
-            let isFirstItemAndHeader = i == 0 && flags.contains(.header)
-            let w = isFirstItemAndHeader ? rect.width : colWidth
+            let w = flags.contains(.spansColumns) ? rect.width : colWidth
             let frame = CGRect(x: x, y: y, width: w, height: 0)
             let view = UIView(frame: frame)
             var prefix = item.getPrefix()
@@ -306,7 +305,7 @@ class ViewController: UIViewController, SettingsViewControllerDelegate {
             let sz = view.frame
             // Enough space for this item?
             let itemIsColBreak = (columnItemCount > 0 && flags.contains(.prefersEmptyColumn))
-            if (col == 1 && twoCols && (sz.height > maxy - y || itemIsColBreak)) {
+            if (col == 0 && twoCols && (sz.height > maxy - y || itemIsColBreak)) {
                 // overflow to 2nd column
                 col += 1
                 columnItemCount = 0
@@ -324,14 +323,14 @@ class ViewController: UIViewController, SettingsViewControllerDelegate {
 
             y = y + sz.height + itemGap
 
-            // Update the verticial origin of the divider and the columns.
-            if isFirstItemAndHeader {
+            if flags.contains(.spansColumns) {
+                // Update the verticial origin of the divider and columns, and start at column 0 again.
                 divider = .vertical(originY: y)
                 colStart = y
-            }
-
-            // Track the number of items in the current column.
-            if !isFirstItemAndHeader {
+                columnItemCount = 0
+                col = 0
+            } else {
+                // Track the number of items in the current column.
                 columnItemCount += 1
             }
 


### PR DESCRIPTION
This change removes the last bit of special-case code in the layout engine that relies on item index in the list to determine layout. Instead of hard-coding that the first item in the list is full-width if it's a header, it checks for the new `.spansColumns` flag which can be applied to an item at any position in the list.