### PR TITLE
refactor(ios): Introduce an explicit source for generating date headers

### DIFF
--- a/ios/StatusPanel.xcodeproj/project.pbxproj
+++ b/ios/StatusPanel.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		D82D0C0621EC1E8700B1C753 /* CalendarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82D0C0521EC1E8700B1C753 /* CalendarViewController.swift */; };
 		D835EC982471D811003E402E /* NetworkExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D835EC972471D811003E402E /* NetworkExtension.framework */; };
 		D89CAF1621ABDDA200B4B314 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89CAF1021ABDDA200B4B314 /* Config.swift */; };
+		D8AAC26726FA60D300215C1A /* CalendarHeaderSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8AAC26626FA60D300215C1A /* CalendarHeaderSource.swift */; };
 		D8CD32D32471D0AA00D82722 /* ExternalAccessory.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8CD32D22471D0AA00D82722 /* ExternalAccessory.framework */; };
 		D8D98E432493019A00F853CA /* NetworkProvisioner.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D98E422493019A00F853CA /* NetworkProvisioner.swift */; };
 		D8DAED7026E3EAA90002F388 /* configuration.json in Resources */ = {isa = PBXBuildFile; fileRef = D8DAED6F26E3EAA90002F388 /* configuration.json */; };
@@ -76,6 +77,7 @@
 		D82D0C0521EC1E8700B1C753 /* CalendarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarViewController.swift; sourceTree = "<group>"; };
 		D835EC972471D811003E402E /* NetworkExtension.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NetworkExtension.framework; path = System/Library/Frameworks/NetworkExtension.framework; sourceTree = SDKROOT; };
 		D89CAF1021ABDDA200B4B314 /* Config.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
+		D8AAC26626FA60D300215C1A /* CalendarHeaderSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarHeaderSource.swift; sourceTree = "<group>"; };
 		D8CD32D22471D0AA00D82722 /* ExternalAccessory.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ExternalAccessory.framework; path = System/Library/Frameworks/ExternalAccessory.framework; sourceTree = SDKROOT; };
 		D8D98E422493019A00F853CA /* NetworkProvisioner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProvisioner.swift; sourceTree = "<group>"; };
 		D8DAED6F26E3EAA90002F388 /* configuration.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = configuration.json; sourceTree = "<group>"; };
@@ -140,6 +142,7 @@
 		D842A3FC265BE81F009C1156 /* Calendar */ = {
 			isa = PBXGroup;
 			children = (
+				D8AAC26626FA60D300215C1A /* CalendarHeaderSource.swift */,
 				DBCA98B221440CD90084B710 /* CalendarSource.swift */,
 				D82D0C0521EC1E8700B1C753 /* CalendarViewController.swift */,
 			);
@@ -368,6 +371,7 @@
 				DB17F92F249E3BAD008CD83E /* CGExtensions.swift in Sources */,
 				DB8AA5F0249DFED100431F63 /* PrivacyModeController.swift in Sources */,
 				DBF1C554223D519C0080CADE /* TFLSettingsController.swift in Sources */,
+				D8AAC26726FA60D300215C1A /* CalendarHeaderSource.swift in Sources */,
 				DBCA98B12143F2B30084B710 /* TFLDataSource.swift in Sources */,
 				DB6CE1472413AB4800FF1160 /* BitmapFontLabel.swift in Sources */,
 				D8DAED7226E3F3320002F388 /* Configuration.swift in Sources */,

--- a/ios/StatusPanel/AppDelegate.swift
+++ b/ios/StatusPanel/AppDelegate.swift
@@ -36,15 +36,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         client = Client(baseUrl: "https://api.statuspanel.io/")
 
         let configuration = try! Bundle.main.configuration()
-        sourceController.add(dataSource:TFLDataSource(configuration: configuration))
-        sourceController.add(dataSource:NationalRailDataSource(configuration: configuration))
-        sourceController.add(dataSource:CalendarSource())
+        sourceController.add(dataSource: CalendarHeaderSource(format: .variable(long: "yMMMMdEEE", short: "yMMMMdEEEE"),
+                                                              flags: [.header, .spansColumns]))
+        sourceController.add(dataSource: TFLDataSource(configuration: configuration))
+        sourceController.add(dataSource: NationalRailDataSource(configuration: configuration))
+        sourceController.add(dataSource: CalendarSource())
         #if DEBUG
-            sourceController.add(dataSource:DummyDataSource())
+            sourceController.add(dataSource: DummyDataSource())
         #endif
-        sourceController.add(dataSource:CalendarSource(forDayOffset: 1, header: "Tomorrow:"))
+        sourceController.add(dataSource: CalendarSource(forDayOffset: 1, header: "Tomorrow:"))
         #if DEBUG
-            sourceController.add(dataSource:DummyDataSource())
+            sourceController.add(dataSource: DummyDataSource())
         #endif
 
         application.registerForRemoteNotifications()

--- a/ios/StatusPanel/Data/Calendar/CalendarHeaderSource.swift
+++ b/ios/StatusPanel/Data/Calendar/CalendarHeaderSource.swift
@@ -1,0 +1,106 @@
+// Copyright (c) 2018-2021 Jason Morley, Tom Sutcliffe
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+
+class CalendarHeaderSource : DataSource {
+
+    enum DateFormat {
+
+        case fixed(format: String)
+        case variable(long: String, short: String)
+
+    }
+
+    class CalendarHeaderItem : DataItemBase {
+
+        let date: Date
+        let format: DateFormat
+        let flags: DataItemFlags
+
+        init(for date: Date, format: DateFormat, flags: DataItemFlags) {
+            self.date = date
+            self.format = format
+            self.flags = flags
+        }
+
+        func getPrefix() -> String { "" }
+
+        var shortFormat: String {
+            switch format {
+            case .fixed(let format):
+                return format
+            case .variable(long: _, short: let short):
+                return short
+            }
+        }
+
+        var longFormat: String {
+            switch format {
+            case .fixed(let format):
+                return format
+            case .variable(long: let long, short: _):
+                return long
+            }
+        }
+
+        func getText(checkFit: (String) -> Bool) -> String {
+            let df = DateFormatter()
+            df.setLocalizedDateFormatFromTemplate(longFormat)
+            let val = df.string(from: date)
+            if !checkFit(val) {
+                // Too long, shorten the day name
+                df.setLocalizedDateFormatFromTemplate(shortFormat)
+                return df.string(from: date)
+            } else {
+                return val
+            }
+        }
+
+        func getSubText() -> String? { nil }
+
+        func getFlags() -> DataItemFlags { flags }
+
+    }
+
+    let format: DateFormat
+    let offset: Int
+    let component: Calendar.Component
+    let flags: DataItemFlags
+
+    init(format: DateFormat, flags: DataItemFlags, offset: Int = 0, component: Calendar.Component = .day) {
+        self.format = format
+        self.flags = flags
+        self.component = component
+        self.offset = offset
+    }
+
+    func fetchData(onCompletion: @escaping Callback) {
+
+        guard let date = Calendar.current.date(byAdding: component, value: offset, to: Date()) else {
+            onCompletion(self, [], StatusPanelError.invalidDate)
+            return
+        }
+        
+        let data = [CalendarHeaderItem(for: date, format: format, flags: flags)]
+        onCompletion(self, data, nil)
+    }
+
+}

--- a/ios/StatusPanel/Data/Calendar/CalendarSource.swift
+++ b/ios/StatusPanel/Data/Calendar/CalendarSource.swift
@@ -21,39 +21,6 @@
 import Foundation
 import EventKit
 
-class CalendarHeader : DataItemBase {
-    init(for date: Date) {
-        self.date = date
-    }
-
-    func getPrefix() -> String {
-        return ""
-    }
-
-    func getText(checkFit: (String) -> Bool) -> String {
-        let df = DateFormatter()
-        df.setLocalizedDateFormatFromTemplate("yMMMMdEEEE")
-        let val = df.string(from: date)
-        if !checkFit(val) {
-            // Too long, shorten the day name
-            df.setLocalizedDateFormatFromTemplate("yMMMMdEEE")
-            return df.string(from: date)
-        } else {
-            return val
-        }
-    }
-
-    func getSubText() -> String? {
-        return nil
-    }
-
-    func getFlags() -> DataItemFlags {
-        return [.header, .spansColumns]
-    }
-
-    let date: Date
-}
-
 class CalendarItem : DataItemBase {
     init(time: String?, title: String, location: String?, flags: DataItemFlags = []) {
         self.time = time
@@ -233,11 +200,4 @@ class CalendarSource : DataSource {
         return result
     }
 
-    static func getHeader() -> DataItemBase {
-        // "Wednesday, 26 February 2020" is a nice long date
-        // let date = Calendar(identifier: .gregorian).date(from: DateComponents(year: 2020, month: 2, day: 26))!
-        let date = Date()
-        return CalendarHeader(for: date)
-    }
 }
-

--- a/ios/StatusPanel/Data/DataSourceController.swift
+++ b/ios/StatusPanel/Data/DataSourceController.swift
@@ -51,8 +51,6 @@ class DataSourceController {
 
         let allCompleted = (completed.count == sources.count)
         var items = [DataItemBase]()
-        // We always want the calendar data source header as the first item
-        items.append(CalendarSource.getHeader())
 
         // Use the ordering of sources, not completedItems
         for source in sources {

--- a/ios/StatusPanel/StatusPanelError.swift
+++ b/ios/StatusPanel/StatusPanelError.swift
@@ -21,7 +21,10 @@
 import Foundation
 
 enum StatusPanelError: Error {
+
     case missingConfiguration
     case invalidResponse(String)
     case invalidUrl
+    case invalidDate
+    
 }


### PR DESCRIPTION
This change introduces `CalendarHeaderSource` which provides a number of formatting options for generating different date headers. The long-term plan is to also use this to generate a localized verison of the "Tomorrow:" text which is currently displayed in the second column, and add configuration options to allow users to choose how their dates are displayed.