### PR TITLE
feat(ios): Select the title font

### DIFF
--- a/ios/StatusPanel/Config.swift
+++ b/ios/StatusPanel/Config.swift
@@ -28,7 +28,8 @@ class Config {
         case darkMode = "darkMode"
         case displaySingleColumn = "displaySingleColumn"
         case dummyData = "dummyData"
-        case font = "font"
+        case titleFont = "titleFont"
+        case bodyFont = "font"
         case lastBackgroundUpdate = "lastBackgroundUpdate"
         case maxLines = "maxLines"
         case privacyMode = "privacyMode"
@@ -220,12 +221,21 @@ class Config {
         }
     }
 
-    var font: String {
+    var titleFont: String {
         get {
-            self.string(for: .font) ?? availableFonts[0].configName
+            self.string(for: .titleFont) ?? availableFonts[0].configName
         }
         set {
-            self.set(newValue, for: .font)
+            self.set(newValue, for: .titleFont)
+        }
+    }
+
+    var bodyFont: String {
+        get {
+            self.string(for: .bodyFont) ?? availableFonts[0].configName
+        }
+        set {
+            self.set(newValue, for: .bodyFont)
         }
     }
 

--- a/ios/StatusPanel/Fonts.swift
+++ b/ios/StatusPanel/Fonts.swift
@@ -96,7 +96,7 @@ class Fonts {
     static let availableFonts = [
         Font(configName: "font6x10_2", humanName: "Guicons Font", bitmapInfo: guiConsFont, subTextScale: 1, textScale: 2, headerScale: 2,
              attribution: "Guicons font taken from https://sourceforge.net/p/fshell/code/ci/default/tree/plugins/consoles/guicons/data/font_6x10.PNG licensed under the EPL. Original author uncertain."),
-        Font(configName: "unifont", humanName: "Unifont 16pt", bitmapInfo: unifont, subTextScale: 1, textScale: 1, headerScale: 2, attribution: unifontAttribution),
+        Font(configName: "unifont", humanName: "Unifont 16pt", bitmapInfo: unifont, subTextScale: 1, textScale: 1, headerScale: 1, attribution: unifontAttribution),
         Font(configName: "unifont_2", humanName: "Unifont 32pt", bitmapInfo: unifont, subTextScale: 1, textScale: 2, headerScale: 2, attribution: unifontAttribution),
         Font(configName: "amiga4ever", humanName: "Amiga Forever", uifont: "Amiga Forever", subTextSize: 8, textSize: 16, headerSize: 24, attribution: """
             "Amiga 4ever" Truetype Font

--- a/ios/StatusPanel/View Controllers/PrivacyModeController.swift
+++ b/ios/StatusPanel/View Controllers/PrivacyModeController.swift
@@ -85,7 +85,7 @@ class PrivacyModeController : UITableViewController, UINavigationControllerDeleg
         if indexPath.row < 2 {
             let frame = cell.contentView.bounds.insetBy(dx: cell.separatorInset.left, dy: 0)
             let redactMode: RedactMode = (indexPath.row == 0) ? .redactLines : .redactWords
-            let label = ViewController.getLabel(frame: frame, font: Config().font, style: .text, redactMode: redactMode)
+            let label = ViewController.getLabel(frame: frame, font: Config().bodyFont, style: .text, redactMode: redactMode)
             label.text = "Redact text good"
             label.sizeToFit()
             label.frame = label.frame.offsetBy(dx: 0, dy: (frame.height - label.bounds.height) / 2)

--- a/ios/StatusPanel/ViewController.swift
+++ b/ios/StatusPanel/ViewController.swift
@@ -116,14 +116,7 @@ class ViewController: UIViewController, SettingsViewControllerDelegate {
     static func getLabel(frame: CGRect, font fontName: String, style: LabelStyle, redactMode: RedactMode = .none) -> UILabel {
         let font = Config().getFont(named: fontName)
         let size = (style == .header) ? font.headerSize : (style == .subText) ? font.subTextSize : font.textSize
-        if let bitmapInfo = font.bitmapInfo {
-            if (bitmapInfo.bitmapName == "font6x10" || font.configName == "unifont") && style == .header {
-                // Special case this, as neither guicons nor Unifont look good as a header font
-                let label = UILabel(frame: frame)
-                label.lineBreakMode = .byWordWrapping
-                label.font = UIFont(name: "Amiga Forever", size: 24)
-                return label
-            }
+        if font.bitmapInfo != nil {
             return BitmapFontLabel(frame: frame, font: font, scale: size, redactMode: redactMode)
         } else {
             let label = UILabel(frame: frame)
@@ -236,6 +229,7 @@ class ViewController: UIViewController, SettingsViewControllerDelegate {
         let redactMode: RedactMode = (shouldRedact ? (config.privacyMode == .redactWords ? .redactWords : .redactLines) : .none)
 
         for item in data {
+            
             let flags = item.getFlags()
             let w = flags.contains(.spansColumns) ? rect.width : colWidth
             let frame = CGRect(x: x, y: y, width: w, height: 0)
@@ -244,9 +238,11 @@ class ViewController: UIViewController, SettingsViewControllerDelegate {
             let numPrefixLines = prefix.split(separator: "\n").count
             var textFrame = CGRect(origin: CGPoint.zero, size: frame.size)
             var itemHeight: CGFloat = 0
+            let font = flags.contains(.header) ? config.titleFont : config.bodyFont
+
             if prefix != "" {
                 let prefixLabel = ViewController.getLabel(frame: textFrame,
-                                                          font: config.font,
+                                                          font: font,
                                                           style: flags.style,
                                                           redactMode: redactMode)
                 prefixLabel.textColor = foregroundColor
@@ -265,7 +261,7 @@ class ViewController: UIViewController, SettingsViewControllerDelegate {
                 }
             }
             let label = ViewController.getLabel(frame: textFrame,
-                                                font: config.font,
+                                                font: font,
                                                 style: flags.style,
                                                 redactMode: redactMode)
             label.numberOfLines = 1 // Temporarily while we're using it in checkFit
@@ -291,7 +287,7 @@ class ViewController: UIViewController, SettingsViewControllerDelegate {
             view.addSubview(label)
             if let subText = item.getSubText() {
                 let subLabel = ViewController.getLabel(frame: textFrame,
-                                                       font: config.font,
+                                                       font: font,
                                                        style: .subText,
                                                        redactMode: redactMode)
                 subLabel.textColor = foregroundColor


### PR DESCRIPTION
This change updates the settings view controller to support setting the title font and body font independently. It also removes the special-case code which magically selected a title font for fonts which didn't perform well as title fonts; we now trust users to figure that out on their own.