### PR TITLE
ci: Ensure the Homebrew copy of Ruby and Python on the path

### DIFF
--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -20,7 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-export PATH="/opt/homebrew/opt/ruby/bin:$PATH"
+export PATH="/opt/homebrew/bin":$PATH
+export PATH="/opt/homebrew/opt/ruby/bin":$PATH
 
 SCRIPTS_DIRECTORY="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 ROOT_DIRECTORY="${SCRIPTS_DIRECTORY}/.."

--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -20,6 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+export PATH="/opt/homebrew/opt/ruby/bin:$PATH"
+
 SCRIPTS_DIRECTORY="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 ROOT_DIRECTORY="${SCRIPTS_DIRECTORY}/.."
 

--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -20,6 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+# TODO: Use local installs of Python and Ruby #170
+#       https://github.com/inseven/statuspanel/issues/170
 export PATH="/opt/homebrew/bin":$PATH
 export PATH="/opt/homebrew/opt/ruby/bin":$PATH
 


### PR DESCRIPTION
Following an update to Xcode 13, there seem to be problems with the built-in Ruby and Python installs. This change ensures the relevant Homebrew locations are on the path so we can use these instead.