### PR TITLE
refactor(ios): Add DisplayContext to fetchData calls

### DIFF
--- a/ios/StatusPanel/Data/Calendar/CalendarHeaderSource.swift
+++ b/ios/StatusPanel/Data/Calendar/CalendarHeaderSource.swift
@@ -92,7 +92,7 @@ class CalendarHeaderSource : DataSource {
         self.offset = offset
     }
 
-    func fetchData(onCompletion: @escaping Callback) {
+    func fetchData(displayContext: DisplayContext, onCompletion: @escaping Callback) {
 
         guard let date = Calendar.current.date(byAdding: component, value: offset, to: Date()) else {
             onCompletion(self, [], StatusPanelError.invalidDate)

--- a/ios/StatusPanel/Data/Calendar/CalendarSource.swift
+++ b/ios/StatusPanel/Data/Calendar/CalendarSource.swift
@@ -157,7 +157,7 @@ class CalendarSource : DataSource {
             let allDay = event.isAllDay || (event.startDate <= dayStart && event.endDate >= dayEnd)
             if allDay {
                 var icon: String?
-                if displayContext.shouldShowIcons(isHeader: false) {
+                if displayContext.showBodyIcons {
                     icon = event.calendar.type == .birthday ? "🎁" : "🗓"
                 }
                 results.append(CalendarItem(icon: icon,

--- a/ios/StatusPanel/Data/DataSource.swift
+++ b/ios/StatusPanel/Data/DataSource.swift
@@ -26,12 +26,8 @@ struct DisplayContext {
         self.showHeaderIcons = showHeaderIcons
     }
 
-    func shouldShowIcons(isHeader: Bool) -> Bool {
-        return isHeader ? showHeaderIcons : showBodyIcons
-    }
-
-    private let showBodyIcons: Bool
-    private let showHeaderIcons: Bool
+    let showBodyIcons: Bool
+    let showHeaderIcons: Bool
 }
 
 protocol DataSource : AnyObject {

--- a/ios/StatusPanel/Data/DataSource.swift
+++ b/ios/StatusPanel/Data/DataSource.swift
@@ -20,9 +20,23 @@
 
 import Foundation
 
+struct DisplayContext {
+    init(showBodyIcons: Bool, showHeaderIcons: Bool) {
+        self.showBodyIcons = showBodyIcons
+        self.showHeaderIcons = showHeaderIcons
+    }
+
+    func shouldShowIcons(isHeader: Bool) -> Bool {
+        return isHeader ? showHeaderIcons : showBodyIcons
+    }
+
+    private let showBodyIcons: Bool
+    private let showHeaderIcons: Bool
+}
+
 protocol DataSource : AnyObject {
     typealias Callback = (DataSource, [DataItemBase], Error?) -> Void
-    func fetchData(onCompletion:@escaping Callback)
+    func fetchData(displayContext: DisplayContext, onCompletion:@escaping Callback)
 }
 
 struct DataItemFlags: OptionSet {
@@ -37,7 +51,6 @@ struct DataItemFlags: OptionSet {
 
 protocol DataItemBase : AnyObject {
 
-    var icon: String? { get }
     var prefix: String { get }
     var flags: DataItemFlags { get }
     var subText: String? { get }
@@ -45,39 +58,21 @@ protocol DataItemBase : AnyObject {
     func getText(checkFit: (String) -> Bool) -> String
 }
 
-extension DataItemBase {
-
-    var iconAndPrefix: String {
-        var elements: [String] = []
-        if let icon = self.icon {
-            elements.append(icon)
-        }
-        let prefix = self.prefix
-        if !prefix.isEmpty {
-            elements.append(prefix)
-        }
-        return elements.joined(separator: " ")
-    }
-
-}
-
 class DataItem : Equatable, DataItemBase {
 
-    let icon: String?
-    let text: String
+    let prefix: String
+    private let text: String
     let flags: DataItemFlags
 
-    init(icon: String?, text: String, flags: DataItemFlags = []) {
-        self.icon = icon
+    init(prefix: String, text: String, flags: DataItemFlags = []) {
+        self.prefix = prefix
         self.text = text
         self.flags = flags
     }
 
     convenience init(text: String, flags: DataItemFlags = []) {
-        self.init(icon: nil, text: text, flags: flags)
+        self.init(prefix: "", text: text, flags: flags)
     }
-
-    var prefix: String { "" }
 
     var subText: String? { nil }
 
@@ -86,6 +81,6 @@ class DataItem : Equatable, DataItemBase {
     }
 
     static func == (lhs: DataItem, rhs: DataItem) -> Bool {
-        return lhs.text == rhs.text && lhs.flags == rhs.flags
+        return lhs.prefix == rhs.prefix && lhs.text == rhs.text && lhs.flags == rhs.flags
     }
 }

--- a/ios/StatusPanel/Data/DataSourceController.swift
+++ b/ios/StatusPanel/Data/DataSourceController.swift
@@ -37,9 +37,13 @@ class DataSourceController {
 
     func fetch() {
         print("Fetching")
+        let config = Config()
+        let showBodyIcons = config.showIcons && config.getFont(named: config.bodyFont).supportsEmoji
+        let showHeaderIcons = config.showIcons && config.getFont(named: config.titleFont).supportsEmoji
+        let displayContext = DisplayContext(showBodyIcons: showBodyIcons, showHeaderIcons: showHeaderIcons)
         completed.removeAll()
         for source in sources {
-            source.fetchData(onCompletion: gotData)
+            source.fetchData(displayContext: displayContext, onCompletion: gotData)
         }
     }
 

--- a/ios/StatusPanel/Data/DummyDataSource.swift
+++ b/ios/StatusPanel/Data/DummyDataSource.swift
@@ -22,7 +22,7 @@ import Foundation
 
 class DummyDataSource : DataSource {
 
-    func fetchData(onCompletion:@escaping Callback) {
+    func fetchData(displayContext: DisplayContext, onCompletion:@escaping Callback) {
         var data: [DataItemBase] = []
         #if DEBUG
         if Config().showDummyData {

--- a/ios/StatusPanel/Data/National Rail/NationalRailDataSource.swift
+++ b/ios/StatusPanel/Data/National Rail/NationalRailDataSource.swift
@@ -92,7 +92,7 @@ class NationalRailDataSource : DataSource {
             return
         }
 
-        let showIcons = (displayContext?.shouldShowIcons(isHeader: false) ?? false)
+        let showIcons = (displayContext?.showBodyIcons ?? false)
         let prefix = showIcons ? "🚊" : ""
         if data.delayedTrains.count == 0 {
             let text: String

--- a/ios/StatusPanel/Data/TFL/TFLDataSource.swift
+++ b/ios/StatusPanel/Data/TFL/TFLDataSource.swift
@@ -92,7 +92,7 @@ class TFLDataSource: DataSource {
     func gotLineData(data: [LineStatus]?, err: Error?) {
         task = nil
         dataItems = []
-        let showIcons = displayContext?.shouldShowIcons(isHeader: false) ?? false
+        let showIcons = displayContext?.showBodyIcons ?? false
         let prefix = showIcons ? "🚇" : ""
         for line in data ?? [] {
             if line.lineStatuses.count < 1 {

--- a/ios/StatusPanel/Data/TFL/TFLDataSource.swift
+++ b/ios/StatusPanel/Data/TFL/TFLDataSource.swift
@@ -52,6 +52,7 @@ class TFLDataSource: DataSource {
     let configuration: Configuration
 
     var dataItems = [DataItem]()
+    var displayContext: DisplayContext?
     var completion: DataSource.Callback?
     var task: URLSessionTask?
 
@@ -59,8 +60,9 @@ class TFLDataSource: DataSource {
         self.configuration = configuration
     }
 
-    func fetchData(onCompletion: @escaping Callback) {
+    func fetchData(displayContext: DisplayContext, onCompletion: @escaping Callback) {
         task?.cancel()
+        self.displayContext = displayContext
         completion = onCompletion
 
         let activeLines = Config().activeTFLLines
@@ -90,6 +92,8 @@ class TFLDataSource: DataSource {
     func gotLineData(data: [LineStatus]?, err: Error?) {
         task = nil
         dataItems = []
+        let showIcons = displayContext?.shouldShowIcons(isHeader: false) ?? false
+        let prefix = showIcons ? "🚇" : ""
         for line in data ?? [] {
             if line.lineStatuses.count < 1 {
                 continue
@@ -106,7 +110,7 @@ class TFLDataSource: DataSource {
                 return
             }
 
-            dataItems.append(DataItem(icon: "🚇", text: "\(name): \(desc)", flags: flags))
+            dataItems.append(DataItem(prefix: prefix, text: "\(name): \(desc)", flags: flags))
         }
         completion?(self, dataItems, err)
     }

--- a/ios/StatusPanel/ViewController.swift
+++ b/ios/StatusPanel/ViewController.swift
@@ -215,7 +215,6 @@ class ViewController: UIViewController, SettingsViewControllerDelegate {
         let foregroundColor = darkMode ? UIColor.white : UIColor.black
         let config = Config()
         let twoCols = config.displayTwoColumns
-        let showIcons = config.showIcons
         let rect = contentView.frame
         let maxy = rect.height - 10 // Leave space for status line
         let midx = rect.width / 2
@@ -233,11 +232,10 @@ class ViewController: UIViewController, SettingsViewControllerDelegate {
             
             let flags = item.flags
             let font = flags.contains(.header) ? config.titleFont : config.bodyFont
-            let fontDetails = Config().getFont(named: font)
             let w = flags.contains(.spansColumns) ? rect.width : colWidth
             let frame = CGRect(x: x, y: y, width: w, height: 0)
             let view = UIView(frame: frame)
-            var prefix = fontDetails.supportsEmoji && showIcons ? item.iconAndPrefix : item.prefix
+            var prefix = item.prefix
             let numPrefixLines = prefix.split(separator: "\n").count
             var textFrame = CGRect(origin: CGPoint.zero, size: frame.size)
             var itemHeight: CGFloat = 0


### PR DESCRIPTION
So that DataSources can decide for themselves whether to add icons to
(not just) the prefix.