### PR TITLE
ci(ios): Select the shipping version of Xcode before building

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -103,7 +103,7 @@ cd "$APP_DIRECTORY"
 echo $APP_CONFIGURATION > "${APP_DIRECTORY}/StatusPanel/configuration.json"
 
 # Select the correct Xcode.
-IOS_XCODE_PATH=${IOS_XCODE_PATH:/Applications/Xcode.app}
+IOS_XCODE_PATH=${IOS_XCODE_PATH:-/Applications/Xcode.app}
 sudo xcode-select --switch "$IOS_XCODE_PATH"
 
 # List the available schemes.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -102,6 +102,9 @@ cd "$APP_DIRECTORY"
 # Create the configuration file.
 echo $APP_CONFIGURATION > "${APP_DIRECTORY}/StatusPanel/configuration.json"
 
+# Select the correct Xcode.
+sudo xcode-select --switch /Applications/Xcode.app
+
 # List the available schemes.
 xcode_project -list
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -103,6 +103,10 @@ cd "$APP_DIRECTORY"
 echo $APP_CONFIGURATION > "${APP_DIRECTORY}/StatusPanel/configuration.json"
 
 # Select the correct Xcode.
+IOS_XCODE_PATH=${IOS_XCODE_PATH:-CHEESE}
+echo "******************"
+echo $IOS_XCODE_PATH
+echo "******************"
 sudo xcode-select --switch /Applications/Xcode.app
 
 # List the available schemes.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -103,11 +103,8 @@ cd "$APP_DIRECTORY"
 echo $APP_CONFIGURATION > "${APP_DIRECTORY}/StatusPanel/configuration.json"
 
 # Select the correct Xcode.
-IOS_XCODE_PATH=${IOS_XCODE_PATH:-CHEESE}
-echo "******************"
-echo $IOS_XCODE_PATH
-echo "******************"
-sudo xcode-select --switch /Applications/Xcode.app
+IOS_XCODE_PATH=${IOS_XCODE_PATH:/Applications/Xcode.app}
+sudo xcode-select --switch "$IOS_XCODE_PATH"
 
 # List the available schemes.
 xcode_project -list


### PR DESCRIPTION
Unfortunately we now need to use two different versions of Xcode for iOS and macOS builds. This change selects the Xcode specified by the `IOS_XCODE_PATH` environment variable configured on the runner.
