### PR TITLE
fix(ios): Use title case for the settings options

### DIFF
--- a/ios/StatusPanel/View Controllers/PrivacyModeController.swift
+++ b/ios/StatusPanel/View Controllers/PrivacyModeController.swift
@@ -91,7 +91,7 @@ class PrivacyModeController : UITableViewController, UINavigationControllerDeleg
             label.frame = label.frame.offsetBy(dx: 0, dy: (frame.height - label.bounds.height) / 2)
             cell.contentView.addSubview(label)
         } else if (indexPath.row == 2) {
-            cell.textLabel?.text = "Use custom image"
+            cell.textLabel?.text = "Custom Image"
         } else if (indexPath.row == 3) {
             cell.contentView.bounds = cell.contentView.bounds.rectWithDifferentHeight(kImageRowHeight)
             cell.accessoryType = .disclosureIndicator

--- a/ios/StatusPanel/View Controllers/SettingsViewController.swift
+++ b/ios/StatusPanel/View Controllers/SettingsViewController.swift
@@ -180,7 +180,7 @@ class SettingsViewController: UITableViewController, UIAdaptivePresentationContr
                 }
             #if DEBUG
             case 3:
-                cell.textLabel?.text = "Show dummy data"
+                cell.textLabel?.text = "Show Dummy Data"
                 let control = UISwitch()
                 control.isOn = config.showDummyData
                 control.addTarget(self, action:#selector(dummyDataSwitchChanged(sender:)), for: .valueChanged)
@@ -215,45 +215,45 @@ class SettingsViewController: UITableViewController, UIAdaptivePresentationContr
             return cell
         case DisplaySettingsSection:
             let row = indexPath.row
-            let cell = UITableViewCell(style: row == 1 || row == 2  || row == 3 ? .value1 : .default, reuseIdentifier: nil)
+            let cell = UITableViewCell(style: row == 2 || row == 3  || row == 4 ? .value1 : .default, reuseIdentifier: nil)
             switch row {
             case 0:
-                cell.textLabel?.text = "Use two columns"
+                cell.textLabel?.text = "Use Two Columns"
                 let control = UISwitch()
                 control.isOn = config.displayTwoColumns
                 control.addTarget(self, action:#selector(columSwitchChanged(sender:)), for: .valueChanged)
                 cell.accessoryView = control
             case 1:
-                cell.textLabel?.text = "Show icons"
+                cell.textLabel?.text = "Show Icons"
                 let control = UISwitch()
                 control.isOn = config.showIcons
                 control.addTarget(self, action:#selector(showIconsChanged(sender:)), for: .valueChanged)
                 cell.accessoryView = control
             case 2:
-                cell.textLabel?.text = "Dark mode"
+                cell.textLabel?.text = "Dark Mode"
                 switch config.darkMode {
                 case .off:
                     cell.detailTextLabel?.text = "Off"
                 case .on:
                     cell.detailTextLabel?.text = "On"
                 case .system:
-                    cell.detailTextLabel?.text = "Use system"
+                    cell.detailTextLabel?.text = "Use System"
                 }
                 cell.accessoryType = .disclosureIndicator
             case 3:
-                cell.textLabel?.text = "Maximum lines per item"
+                cell.textLabel?.text = "Maximum Lines per Item"
                 let val = config.maxLines
                 cell.detailTextLabel?.text = val == 0 ? "Unlimited" : String(format: "%d", val)
                 cell.accessoryType = .disclosureIndicator
             case 4:
-                cell.textLabel?.text = "Privacy mode"
+                cell.textLabel?.text = "Privacy Mode"
                 switch config.privacyMode {
                 case .redactLines:
-                    cell.detailTextLabel?.text = "Redact lines"
+                    cell.detailTextLabel?.text = "Redact Lines"
                 case .redactWords:
-                    cell.detailTextLabel?.text = "Redact words"
+                    cell.detailTextLabel?.text = "Redact Words"
                 case .customImage:
-                    cell.detailTextLabel?.text = "Custom image"
+                    cell.detailTextLabel?.text = "Custom Image"
                 }
                 cell.accessoryType = .disclosureIndicator
             default:


### PR DESCRIPTION
iOS uses title case for forms (see Settings.app); we should too.