### PR TITLE
fix(ios): Tighten line spacing on unifont-16

### DIFF
--- a/ios/StatusPanel/Data/DummyDataSource.swift
+++ b/ios/StatusPanel/Data/DummyDataSource.swift
@@ -48,8 +48,8 @@ class DummyDataSource : DataSource {
                 specialChars.append(str)
             }
             let specialCharsStr = specialChars.joined(separator: "")
+            let specialCharsItem = CalendarItem(icon: "🗓", title: specialCharsStr, location: specialCharsStr)
             let dummyData: [DataItemBase] = [
-                CalendarItem(icon: "🗓", title: specialCharsStr, location: specialCharsStr),
                 CalendarItem(time: "06:00",
                              title: "Something that has really long text that needs to wrap. Like, really really long!",
                              location: "A place that is also really really lengthy"),
@@ -58,6 +58,9 @@ class DummyDataSource : DataSource {
                 CalendarItem(time: "09:40", title: "Some text wot is multiline", location: nil),
             ]
             data.append(contentsOf: dummyData)
+            if Config().showIcons {
+                data.append(specialCharsItem)
+            }
         }
         #endif
         onCompletion(self, data, nil)

--- a/ios/StatusPanel/Fonts.swift
+++ b/ios/StatusPanel/Fonts.swift
@@ -100,6 +100,16 @@ class Fonts {
             self.attribution = attribution
             self.supportsEmoji = true
         }
+
+        var textHeight: Int {
+            if let bitmapInfo = self.bitmapInfo {
+                // Bitmap font, textSize is scale factor
+                return bitmapInfo.charh * textSize
+            } else {
+                // UIFont, textSize is the font size
+                return textSize
+            }
+        }
     }
 
     private static let castpixelAttribution = """

--- a/ios/StatusPanel/ViewController.swift
+++ b/ios/StatusPanel/ViewController.swift
@@ -222,7 +222,8 @@ class ViewController: UIViewController, SettingsViewControllerDelegate {
         var x : CGFloat = 5
         var y : CGFloat = 0
         let colWidth = twoCols ? (rect.width / 2 - x * 2) : rect.width - x
-        let itemGap : CGFloat = 10
+        let bodyFont = config.getFont(named: config.bodyFont)
+        let itemGap = CGFloat(min(10, bodyFont.textHeight / 2)) // ie 50% of the body text line height up to a max of 10px
         var colStart = y
         var col = 0
         var columnItemCount = 0 // Number of items assigned to the current column


### PR DESCRIPTION
Previously it was hard-coded to 10, now use half the line height.
Meaning for unifont-16, this reduces the inter-item gap to 8 pixels,
which I think looks better.

Also made 10px be the maximum so that unifont-32 doesn't look overly
spaced out.

Also made DummyDataSource honour showIcons as oftentimes showing all
the special chars in one big block isn't that useful and showIcons
offers a convenient way of hiding that for testing.

Before:
![Spacing_before](https://user-images.githubusercontent.com/2305420/135750961-1cc3043b-b73d-4f4c-8792-d43ce9b04404.png)

After:
![Spacing_after](https://user-images.githubusercontent.com/2305420/135750968-3998a1fb-024a-4ff7-a067-2ba1493db194.png)

@jbmorley what do you think? It's not all that noticeable unless you flick between them but unifont-16 has felt slightly too spacious for me since we added it.
