### PR TITLE
fix(ios): Remove font-specific workaround from NationalRailDataSource

### DIFF
--- a/ios/StatusPanel/Data/DummyDataSource.swift
+++ b/ios/StatusPanel/Data/DummyDataSource.swift
@@ -54,7 +54,7 @@ class DummyDataSource : DataSource {
                              title: "Something that has really long text that needs to wrap. Like, really really long!",
                              location: "A place that is also really really lengthy"),
                 DataItem(text: "Northern line: part suspended", flags: [.warning]),
-                DataItem(text: "07:44 to CBG:\u{2028}Cancelled", flags: [.warning]),
+                DataItem(text: "07:44 to CBG: Cancelled", flags: [.warning]),
                 CalendarItem(time: "09:40", title: "Some text wot is multiline", location: nil),
             ]
             data.append(contentsOf: dummyData)

--- a/ios/StatusPanel/Data/National Rail/NationalRailDataSource.swift
+++ b/ios/StatusPanel/Data/National Rail/NationalRailDataSource.swift
@@ -95,10 +95,7 @@ class NationalRailDataSource : DataSource {
         }
 
         for delay in data.delayedTrains {
-            // If we don't force a line break here, UILabel breaks the line after the "to"
-            // which makes the resulting text look a bit unbalanced. But it only does this
-            // when using the Amiga Forever font in non-editing mode (!?)
-            var text = "\(delay.std) \(sourceCrs!) to \(targetCrs!):\u{2028}"
+            var text = "\(delay.std) \(sourceCrs!) to \(targetCrs!): "
             if delay.isCancelled {
                 text += "Cancelled"
             } else {


### PR DESCRIPTION
Since it only applies to a font we don't generally use for the body
text any more anyway, and looks bad in the fonts we _do_ use (ie
guicons and unifont-16)