### PR TITLE
fix(ios): Fix regression in redact words

### DIFF
--- a/ios/StatusPanel/BitmapFontLabel.swift
+++ b/ios/StatusPanel/BitmapFontLabel.swift
@@ -155,7 +155,7 @@ class BitmapFontLabel: UILabel {
                 let chY = y + line * lineHeight * scale + (scaledCharHeight - chImg.height) / 2
                 let rect = CGRect(x: x, y: chY, width: chImg.width, height: chImg.height)
                 if redactMode == .redactLines || (redactMode == .redactWords && !ch.isWhitespace) {
-                    ctx.addRect(rect)
+                    ctx.fill(rect)
                 } else {
                     ctx.saveGState()
                     ctx.clip(to: rect, mask: chImg)


### PR DESCRIPTION
The change to saving and restoring the context state caused us to only show a redacted block for the last word of each line.