### PR TITLE
fix(ios): Use the correct Done button style in Settings

### DIFF
--- a/ios/StatusPanel/Base.lproj/Main.storyboard
+++ b/ios/StatusPanel/Base.lproj/Main.storyboard
@@ -86,13 +86,7 @@
                             <outlet property="delegate" destination="539-wo-ocb" id="lhk-er-PYQ"/>
                         </connections>
                     </tableView>
-                    <navigationItem key="navigationItem" title="Settings" id="MMN-cF-13V">
-                        <barButtonItem key="leftBarButtonItem" title="Done" id="4Xn-7A-Dbg">
-                            <connections>
-                                <action selector="cancelTapped:" destination="539-wo-ocb" id="dyo-Nq-ELp"/>
-                            </connections>
-                        </barButtonItem>
-                    </navigationItem>
+                    <navigationItem key="navigationItem" title="Settings" id="MMN-cF-13V"/>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Qgi-lm-KnI" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
@@ -220,11 +214,11 @@
                                         <rect key="frame" x="16" y="18" width="288" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="T3J-yi-VzE" id="a8l-Ns-0wa">
-                                            <rect key="frame" x="0.0" y="0.0" width="248" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="251.5" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Off" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="voL-9n-Ns7">
-                                                    <rect key="frame" x="16" y="0.0" width="224" height="43.5"/>
+                                                    <rect key="frame" x="16" y="0.0" width="227.5" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>

--- a/ios/StatusPanel/View Controllers/SettingsViewController.swift
+++ b/ios/StatusPanel/View Controllers/SettingsViewController.swift
@@ -43,8 +43,15 @@ class SettingsViewController: UITableViewController, UIAdaptivePresentationContr
 
     var devices: [(String, String)] = []
 
+    var doneButtonItem: UIBarButtonItem {
+        return UIBarButtonItem(barButtonSystemItem: .done,
+                               target: self,
+                               action: #selector(cancelTapped(_:)))
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.navigationItem.leftBarButtonItem = doneButtonItem
         self.navigationItem.rightBarButtonItem = editButtonItem
         self.tableView.allowsSelectionDuringEditing = true
     }
@@ -67,9 +74,7 @@ class SettingsViewController: UITableViewController, UIAdaptivePresentationContr
                 tableView.insertSections([1], with: .fade)
             }
         } else {
-            self.navigationItem.setLeftBarButton(UIBarButtonItem(barButtonSystemItem: .done,
-                                                                 target: self,
-                                                                 action: #selector(cancelTapped(_:))), animated: true)
+            self.navigationItem.setLeftBarButton(doneButtonItem, animated: true)
             tableView.performBatchUpdates {
                 tableView.deleteSections([1], with: .fade)
                 tableView.insertSections([1, 2, 3, 4, 5], with: .fade)


### PR DESCRIPTION
The 'Done' button configured in the Storyboard was not using the correct style. This change configures the button programatically in `viewDidLoad` to ensure it matches subsequent updates.