### PR TITLE
fix(ios): Pre-process the images before setting the previews

### DIFF
--- a/ios/StatusPanel/Client.swift
+++ b/ios/StatusPanel/Client.swift
@@ -70,12 +70,9 @@ class Client {
         }
     }
 
-    func upload(image: UIImage, privacyImage: UIImage, completion: @escaping (Bool) -> Void) {
+    func upload(image: Data, privacyImage: Data, completion: @escaping (Bool) -> Void) {
         DispatchQueue.global().async {
             print("Uploading new images")
-
-            let payloads = Panel.rlePayloads(for: [image, privacyImage])
-            let images = payloads.map { $0.0 }
 
             var devices = Config().devices
             if devices.count == 0 {
@@ -99,7 +96,7 @@ class Client {
                         nextUpload(false)
                         return
                     }
-                    self.uploadImages(images, deviceid: id, publickey: pubkey, completion: nextUpload)
+                    self.uploadImages([image, privacyImage], deviceid: id, publickey: pubkey, completion: nextUpload)
                 }
             }
             nextUpload(false)


### PR DESCRIPTION
In my desire to improve performance and do everything on a background queue, I failed to pre-process the update images before displaying them. 🤦🏻‍♂️