### PR TITLE
fix(ios): Small UI improvements to the WiFi setup flow

### DIFF
--- a/ios/StatusPanel/AppDelegate.swift
+++ b/ios/StatusPanel/AppDelegate.swift
@@ -89,23 +89,25 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             print("Unrecognised operation \(operation)")
             return false
         }
-        let deviceid = map["id"]!
-        let pubkey = map["pk"]!
+
+        guard let deviceId = map["id"],
+              let publicKey = map["pk"] else {
+                  return false
+              }
+
+        let device = Device(id: deviceId, publicKey: publicKey)
 
         // Now try and provision the panel
         if let panelSsid = map["s"] {
             // If the panel is telling us about an SSID, it's in AP mode and needs wifi credentials
-            let storyboard = window?.rootViewController?.storyboard
-            let navvc = storyboard?.instantiateViewController(identifier: "WifiProvisionerController") as! UINavigationController
-
-            let vc = navvc.topViewController as! WifiProvisionerController
-            vc.panelIdentifer = deviceid
-            vc.panelPubkey = pubkey
-            vc.setHotspotCredentials(ssid: panelSsid, password: pubkey)
-            window?.rootViewController?.present(navvc, animated: true, completion: nil)
+            let viewController: WifiProvisionerController = .newInstance()
+            viewController.device = device
+            viewController.setHotspotCredentials(ssid: panelSsid, password: device.publicKey)
+            window?.rootViewController?.present(UINavigationController(rootViewController: viewController),
+                                                animated: true,
+                                                completion: nil)
             return true
         } else {
-            let device = Device(id: deviceid, publicKey: pubkey)
             addDevice(device)
             return true
         }

--- a/ios/StatusPanel/Base.lproj/Main.storyboard
+++ b/ios/StatusPanel/Base.lproj/Main.storyboard
@@ -286,23 +286,22 @@
         <!--Set Wifi credentials-->
         <scene sceneID="aQF-3S-Wus">
             <objects>
-                <tableViewController title="Set Wifi credentials" id="YhL-nZ-Blj" customClass="WifiProvisionerController" customModule="StatusPanel" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="singleLineEtched" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="pEX-JO-T1I">
+                <tableViewController storyboardIdentifier="WifiProvisionerController" title="Set Wifi credentials" id="YhL-nZ-Blj" customClass="WifiProvisionerController" customModule="StatusPanel" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="insetGrouped" separatorStyle="singleLineEtched" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="pEX-JO-T1I">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="1024"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                         <sections>
                             <tableViewSection headerTitle="" id="zQC-UW-i9y">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="7jP-7P-ewK">
-                                        <rect key="frame" x="0.0" y="35" width="320" height="43.5"/>
+                                        <rect key="frame" x="16" y="35" width="288" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="7jP-7P-ewK" id="Asb-cs-sek">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="288" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <textField opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="SSID" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="6et-2T-B7U">
-                                                    <rect key="frame" x="16" y="5" width="288" height="34"/>
+                                                    <rect key="frame" x="16" y="5" width="256" height="34"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="alphabet" returnKeyType="next" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
@@ -314,14 +313,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="43.5" id="o7Y-vH-K5e">
-                                        <rect key="frame" x="0.0" y="78.5" width="320" height="43.5"/>
+                                        <rect key="frame" x="16" y="78.5" width="288" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="o7Y-vH-K5e" id="zED-Oq-TZ2">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="288" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <textField opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Password" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="xqb-C6-TAR">
-                                                    <rect key="frame" x="16" y="4" width="288" height="34"/>
+                                                    <rect key="frame" x="16" y="4" width="256" height="34"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <textInputTraits key="textInputTraits" returnKeyType="done" textContentType="password"/>
@@ -334,14 +333,14 @@
                             <tableViewSection id="3J3-Fl-CHb">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="khd-P0-42J" style="IBUITableViewCellStyleDefault" id="6j6-hF-T9s">
-                                        <rect key="frame" x="0.0" y="158" width="320" height="43.5"/>
+                                        <rect key="frame" x="16" y="158" width="288" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="6j6-hF-T9s" id="Rka-Jz-0OI">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="288" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Provision" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="khd-P0-42J">
-                                                    <rect key="frame" x="16" y="0.0" width="288" height="43.5"/>
+                                                    <rect key="frame" x="16" y="0.0" width="256" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" systemColor="secondaryLabelColor"/>
@@ -406,23 +405,7 @@
                     <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                 </view>
             </objects>
-            <point key="canvasLocation" x="4468" y="4572"/>
-        </scene>
-        <!--Navigation Controller-->
-        <scene sceneID="S37-9W-SxX">
-            <objects>
-                <navigationController storyboardIdentifier="WifiProvisionerController" id="7em-7N-aPo" sceneMemberID="viewController">
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="yH0-aQ-BPg">
-                        <rect key="frame" x="0.0" y="20" width="320" height="50"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </navigationBar>
-                    <connections>
-                        <segue destination="YhL-nZ-Blj" kind="relationship" relationship="rootViewController" id="VbY-PX-vzy"/>
-                    </connections>
-                </navigationController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="dOh-36-d5j" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="3158" y="4527"/>
+            <point key="canvasLocation" x="4123" y="4457"/>
         </scene>
         <!--Privacy Mode-->
         <scene sceneID="sGG-fc-weP">

--- a/ios/StatusPanel/View Controllers/SettingsViewController.swift
+++ b/ios/StatusPanel/View Controllers/SettingsViewController.swift
@@ -458,16 +458,27 @@ class SettingsViewController: UITableViewController, UIAdaptivePresentationContr
         case DevicesSection:
             let prevCount = devices.count
             if indexPath.row == (prevCount == 0 ? 1 : prevCount) {
-                devices.append(("DummyDevice\(indexPath.row)", ""))
+                let device = Device(id: "DummyDevice\(indexPath.row)", publicKey: "")
+                devices.append((device.id, device.publicKey))
                 Config().devices = devices
-                tableView.performBatchUpdates({
+                tableView.performBatchUpdates {
                     tableView.deselectRow(at: indexPath, animated: true)
-                    if (prevCount == 0) {
+                    if prevCount == 0 {
                         tableView.deleteRows(at: [IndexPath(row: prevCount, section: DevicesSection)], with: .fade)
                     }
                     tableView.insertRows(at: [IndexPath(row: prevCount, section: DevicesSection)], with: .fade)
-                }, completion: nil)
-                vcid = "WifiProvisionerController"
+                }
+                guard let url = URL(string: "statuspanel:r")?.settingQueryItems([
+                    URLQueryItem(name: "id", value: device.id),
+                    URLQueryItem(name: "pk", value: device.publicKey),
+                    URLQueryItem(name: "s", value: ""),
+                ]) else {
+                    return
+                }
+                dismiss(animated: true) {
+                    UIApplication.shared.open(url, options: [:])
+                }
+                return
             } else {
                 return
             }


### PR DESCRIPTION
Switch to using the inset grouped appearance for the `WifiProvisionerController` which is now the platform default for forms. This change also includes some drive-by refactoring to simplify the configuration of the view controller and prepare it for reuse in other flows by removing the top-level `UINavigationController` from the storyboard.