### PR TITLE
refactor(ios): Encapsulate the remote URL parsing code

### DIFF
--- a/ios/StatusPanel.xcodeproj/project.pbxproj
+++ b/ios/StatusPanel.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		D8DC8D8126E1ADAF004B081D /* Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = D8DC8D7E26E1ADAF004B081D /* Debug.xcconfig */; };
 		D8DC8D8226E1ADAF004B081D /* Common.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = D8DC8D7F26E1ADAF004B081D /* Common.xcconfig */; };
 		D8DC8D8326E1ADAF004B081D /* Release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = D8DC8D8026E1ADAF004B081D /* Release.xcconfig */; };
+		D8E285AD271A4547001738A8 /* ExternalOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E285AC271A4547001738A8 /* ExternalOperation.swift */; };
 		D8E285AF271A45CE001738A8 /* Device.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E285AE271A45CE001738A8 /* Device.swift */; };
 		D8E6839C270DF11800504B5E /* DataSourceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E6839B270DF11800504B5E /* DataSourceType.swift */; };
 		D8EED7F12630EF19009E2166 /* Sodium in Frameworks */ = {isa = PBXBuildFile; productRef = D8EED7F02630EF19009E2166 /* Sodium */; };
@@ -133,6 +134,7 @@
 		D8DC8D7E26E1ADAF004B081D /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		D8DC8D7F26E1ADAF004B081D /* Common.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Common.xcconfig; sourceTree = "<group>"; };
 		D8DC8D8026E1ADAF004B081D /* Release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
+		D8E285AC271A4547001738A8 /* ExternalOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalOperation.swift; sourceTree = "<group>"; };
 		D8E285AE271A45CE001738A8 /* Device.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Device.swift; sourceTree = "<group>"; };
 		D8E6839B270DF11800504B5E /* DataSourceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataSourceType.swift; sourceTree = "<group>"; };
 		D8EED7EF2630EEFF009E2166 /* swift-sodium */ = {isa = PBXFileReference; lastKnownFileType = folder; path = "swift-sodium"; sourceTree = "<group>"; };
@@ -204,6 +206,7 @@
 			isa = PBXGroup;
 			children = (
 				D81DA7BF2712953D0052D32C /* Localization.swift */,
+				D8E285AC271A4547001738A8 /* ExternalOperation.swift */,
 				D8CC37B02717887A00938C5D /* Panel.swift */,
 			);
 			path = Utilities;
@@ -533,6 +536,7 @@
 				D83CC5202707532400260DC1 /* AnyDataSource.swift in Sources */,
 				DBCA98B321440CD90084B710 /* CalendarSource.swift in Sources */,
 				DB5E9DA1241562ED009F3807 /* StringUtils.swift in Sources */,
+				D8E285AD271A4547001738A8 /* ExternalOperation.swift in Sources */,
 				DBCA98B52144421F0084B710 /* DataSource.swift in Sources */,
 				DB62F333224F89C200CA5E64 /* StationPickerController.swift in Sources */,
 				D81DA7C02712953D0052D32C /* Localization.swift in Sources */,

--- a/ios/StatusPanel/Utilities/ExternalOperation.swift
+++ b/ios/StatusPanel/Utilities/ExternalOperation.swift
@@ -1,0 +1,78 @@
+// Copyright (c) 2018-2021 Jason Morley, Tom Sutcliffe
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+
+enum ExternalOperation {
+
+    case registerDevice(Device)
+    case registerDeviceAndConfigureWiFi(Device, ssid: String)
+
+    init?(url: URL) {
+
+        guard let components = NSURLComponents(url: url, resolvingAgainstBaseURL: true),
+            let operation = components.path,
+            let params = components.queryItems else {
+                return nil
+            }
+
+        var map: [String : String] = [:]
+        for queryItem in params {
+            if let val = queryItem.value {
+                map[queryItem.name] = val
+            }
+        }
+
+        switch operation {
+        case "r":
+            guard let id = map["id"],
+                  let publicKey = map["pk"] else {
+                      return nil
+                  }
+            let device = Device(id: id, publicKey: publicKey)
+            if let ssid = map["s"] {
+                self = .registerDeviceAndConfigureWiFi(device, ssid: ssid)
+            } else {
+                self = .registerDevice(device)
+            }
+            return
+        default:
+            return nil
+        }
+
+    }
+
+    var url: URL {
+        switch self {
+        case .registerDevice(let device):
+            return URL(string: "statuspanel:r")!.settingQueryItems([
+                URLQueryItem(name: "id", value: device.id),
+                URLQueryItem(name: "pk", value: device.publicKey),
+            ])!
+        case .registerDeviceAndConfigureWiFi(let device, ssid: let ssid):
+            return URL(string: "statuspanel:r")!.settingQueryItems([
+                URLQueryItem(name: "id", value: device.id),
+                URLQueryItem(name: "pk", value: device.publicKey),
+                URLQueryItem(name: "s", value: ssid),
+            ])!
+        }
+    }
+
+}

--- a/ios/StatusPanel/View Controllers/SettingsViewController.swift
+++ b/ios/StatusPanel/View Controllers/SettingsViewController.swift
@@ -468,15 +468,10 @@ class SettingsViewController: UITableViewController, UIAdaptivePresentationContr
                     }
                     tableView.insertRows(at: [IndexPath(row: prevCount, section: DevicesSection)], with: .fade)
                 }
-                guard let url = URL(string: "statuspanel:r")?.settingQueryItems([
-                    URLQueryItem(name: "id", value: device.id),
-                    URLQueryItem(name: "pk", value: device.publicKey),
-                    URLQueryItem(name: "s", value: ""),
-                ]) else {
-                    return
-                }
-                dismiss(animated: true) {
-                    UIApplication.shared.open(url, options: [:])
+                let operation: ExternalOperation = .registerDeviceAndConfigureWiFi(device, ssid: device.publicKey)
+                self.dismiss(animated: true) {
+                    self.delegate?.didDismiss(settingsViewController: self)
+                    UIApplication.shared.open(operation.url, options: [:])
                 }
                 return
             } else {


### PR DESCRIPTION
This change moves the remote URL handling from `application(_:open:options:)` to a new `ExternalOperation` struct and uses this to both generate URLs for adding dummy devices and parsing remote URLs from the Camera QR code scanner, and from `QRCodeViewController`. This is preparatory work for reusing `WifiProvisionerController` in a full wizard flow for adding devices.