### PR TITLE
fix(ios): Show the build date in localtime

### DIFF
--- a/ios/StatusPanel.xcodeproj/project.pbxproj
+++ b/ios/StatusPanel.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		D8DC8D8126E1ADAF004B081D /* Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = D8DC8D7E26E1ADAF004B081D /* Debug.xcconfig */; };
 		D8DC8D8226E1ADAF004B081D /* Common.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = D8DC8D7F26E1ADAF004B081D /* Common.xcconfig */; };
 		D8DC8D8326E1ADAF004B081D /* Release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = D8DC8D8026E1ADAF004B081D /* Release.xcconfig */; };
+		D8DD98FC271EE98A004088CD /* UIApplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8DD98FB271EE98A004088CD /* UIApplication.swift */; };
 		D8E285AD271A4547001738A8 /* ExternalOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E285AC271A4547001738A8 /* ExternalOperation.swift */; };
 		D8E285AF271A45CE001738A8 /* Device.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E285AE271A45CE001738A8 /* Device.swift */; };
 		D8E6839C270DF11800504B5E /* DataSourceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E6839B270DF11800504B5E /* DataSourceType.swift */; };
@@ -153,6 +154,7 @@
 		D8DC8D7E26E1ADAF004B081D /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		D8DC8D7F26E1ADAF004B081D /* Common.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Common.xcconfig; sourceTree = "<group>"; };
 		D8DC8D8026E1ADAF004B081D /* Release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
+		D8DD98FB271EE98A004088CD /* UIApplication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIApplication.swift; sourceTree = "<group>"; };
 		D8E285AC271A4547001738A8 /* ExternalOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalOperation.swift; sourceTree = "<group>"; };
 		D8E285AE271A45CE001738A8 /* Device.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Device.swift; sourceTree = "<group>"; };
 		D8E6839B270DF11800504B5E /* DataSourceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataSourceType.swift; sourceTree = "<group>"; };
@@ -359,6 +361,7 @@
 				D89104842707B99F0020A2CF /* UIViewController.swift */,
 				DB981489270887590029BA0A /* UnicodeExtensions.swift */,
 				D8293A0B26F787D3008CE13B /* URL.swift */,
+				D8DD98FB271EE98A004088CD /* UIApplication.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -582,6 +585,7 @@
 				DB5E9DA1241562ED009F3807 /* StringUtils.swift in Sources */,
 				D8E285AD271A4547001738A8 /* ExternalOperation.swift in Sources */,
 				DBCA98B52144421F0084B710 /* DataSource.swift in Sources */,
+				D8DD98FC271EE98A004088CD /* UIApplication.swift in Sources */,
 				DB62F333224F89C200CA5E64 /* StationPickerController.swift in Sources */,
 				D81DA7C02712953D0052D32C /* Localization.swift in Sources */,
 				D8C20D2B271CC1E600F3F22A /* FontLabelTableViewCell.swift in Sources */,

--- a/ios/StatusPanel/Extensions/UIApplication.swift
+++ b/ios/StatusPanel/Extensions/UIApplication.swift
@@ -1,0 +1,65 @@
+// Copyright (c) 2018-2021 Jason Morley, Tom Sutcliffe
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import UIKit
+
+extension UIApplication {
+
+    var version: String? {
+        return Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+    }
+
+    var build: String? {
+        return Bundle.main.infoDictionary?["CFBundleVersion"] as? String
+    }
+
+    var utcBuildDate: Date? {
+        guard let build = self.build,
+              build.count == 18
+        else {
+            return nil
+        }
+        let dateString = String(build.prefix(10))
+        let inputDateFormatter = DateFormatter()
+        inputDateFormatter.dateFormat = "yyMMddHHmm"
+        inputDateFormatter.timeZone = TimeZone(abbreviation: "UTC")
+        return inputDateFormatter.date(from: dateString)
+    }
+
+    var commit: String? {
+        guard let build = self.build,
+              build.count == 18
+        else {
+            return nil
+        }
+        guard let shaValue = Int(String(build.suffix(8))) else {
+            return nil
+        }
+        return String(format: "%02x", shaValue)
+    }
+
+    var commitUrl: URL? {
+        guard let sha = self.commit else {
+            return nil
+        }
+        return URL(string: "https://github.com/inseven/statuspanel/commit")?.appendingPathComponent(sha)
+    }
+
+}

--- a/ios/StatusPanel/Views/AboutView.swift
+++ b/ios/StatusPanel/Views/AboutView.swift
@@ -28,62 +28,31 @@ struct AboutView: View {
 
     @Environment(\.presentationMode) var presentationMode
 
-    var version: String? {
-        return Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
-    }
-
-    var build: String? {
-        return Bundle.main.infoDictionary?["CFBundleVersion"] as? String
-    }
-
-    var date: String? {
-        guard let build = self.build,
-              build.count == 18
-        else {
-            return nil
-        }
-        let dateString = String(build.prefix(10))
-        let inputDateFormatter = DateFormatter()
-        inputDateFormatter.dateFormat = "yyMMddHHmm"
-        guard let date = inputDateFormatter.date(from: dateString) else {
-            return nil
-        }
+    private static let dateFormatter: DateFormatter = {
         let dateFormatter = DateFormatter()
         dateFormatter.dateStyle = .short
         dateFormatter.timeStyle = .short
-        return dateFormatter.string(from: date)
-    }
+        return dateFormatter
+    }()
 
-    var sha: String? {
-        guard let build = self.build,
-              build.count == 18
-        else {
+    private var date: String? {
+        guard let date = UIApplication.shared.utcBuildDate else {
             return nil
         }
-        guard let shaValue = Int(String(build.suffix(8))) else {
-            return nil
-        }
-        return String(format: "%02x", shaValue)
+        return Self.dateFormatter.string(from: date)
     }
 
-    var commitUrl: URL? {
-        guard let sha = self.sha else {
-            return nil
-        }
-        return URL(string: "https://github.com/inseven/statuspanel/commit")?.appendingPathComponent(sha)
-    }
-
-    var contributors = [
+    private var contributors = [
         "Jason Morley",
         "Tom Sutcliffe",
     ]
 
-    var people = [
+    private var people = [
         "Lukas Fittl",
         "Pavlos Vinieratos",
     ]
 
-    var fonts: [Fonts.Font] {
+    private var fonts: [Fonts.Font] {
         Config().availableFonts.sorted { $0.humanReadableName < $1.humanReadableName }
     }
 
@@ -91,16 +60,16 @@ struct AboutView: View {
         NavigationView {
             Form {
                 Section {
-                    ValueRow(text: "Version", detailText: version ?? "")
-                    ValueRow(text: "Build", detailText: build ?? "")
+                    ValueRow(text: "Version", detailText: UIApplication.shared.version ?? "")
+                    ValueRow(text: "Build", detailText: UIApplication.shared.build ?? "")
                     ValueRow(text: "Date", detailText: date ?? "")
                     Button {
-                        guard let url = commitUrl else {
+                        guard let url = UIApplication.shared.commitUrl else {
                             return
                         }
                         UIApplication.shared.open(url, options: [:])
                     } label: {
-                        ValueRow(text: "Commit", detailText: sha ?? "")
+                        ValueRow(text: "Commit", detailText: UIApplication.shared.commit ?? "")
                     }
                 }
                 Section(header: Text("Contributors")) {


### PR DESCRIPTION
This change also includes a small refactor to move the versioning convenience APIs onto a `UIApplication` extension.