### PR TITLE
fix(firmware): Forget Wi-Fi details when performing factory reset

### DIFF
--- a/nodemcu/main.lua
+++ b/nodemcu/main.lua
@@ -278,22 +278,26 @@ function go()
     end
 end
 
+function Set (list)
+  local set = {}
+  for _, l in ipairs(list) do set[l] = true end
+  return set
+end
+
 function resetDeviceState()
-    local files = {
-        "deviceid",
-        "pk",
-        "sk",
-        "last_modified",
-        "img_1",
-        "img_1_hash",
-        "img_2",
-        "img_2_hash",
-    }
-    for _, name in ipairs(files) do
-        file.remove(name)
+
+    -- reset the wifi
+    wifi.stop()
+    wifi.mode(wifi.STATION)
+    wifi.sta.config({ssid="", auto=false}, true)
+
+    -- remove the files, preserving init.lua and root.pem
+    persist = Set { "init.lua", "root.pem" }
+    for k,v in pairs(file.list()) do
+        if not persist[k] then
+            file.remove(k)
+        end
     end
-    setCurrentDisplayIdentifier(nil)
-    network.setDeviceId(nil)
 end
 
 provisioningSocket = nil

--- a/scripts/firmware.py
+++ b/scripts/firmware.py
@@ -211,27 +211,7 @@ def command_configure_wifi(options):
 ])
 def command_reset(options):
     device = get_device(options)
-    execute_lua(device, """
-
-function Set (list)
-  local set = {}
-  for _, l in ipairs(list) do set[l] = true end
-  return set
-end
-
--- remove the files, preserving init.lua and root.pem
-persist = Set { "init.lua", "root.pem" }
-for k,v in pairs(file.list()) do
-    if not persist[k] then
-        file.remove(k)
-    end
-end
-
--- reset the wifi
-wifi.stop()
-wifi.mode(wifi.STATION)
-wifi.sta.config({ssid="", auto=false}, true)
-""")
+    execute_lua(device, "resetDeviceState()")
 
 
 @cli.command("script", help="run a Lua script on the device", arguments=[


### PR DESCRIPTION
Previously, factory reset only unpaired the device. This change ensures that all stored files are cleared out and the Wi-Fi settings are forgotten.