### PR TITLE
feat(ios): Support emoji in TTF fonts

### DIFF
--- a/ios/StatusPanel.xcodeproj/project.pbxproj
+++ b/ios/StatusPanel.xcodeproj/project.pbxproj
@@ -95,6 +95,7 @@
 		DBF15BC72471A61E004AA972 /* WifiProvisionerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBF15BC62471A61E004AA972 /* WifiProvisionerController.swift */; };
 		DBF15EFD21597808006B0A58 /* NationalRailDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBF15EFC21597808006B0A58 /* NationalRailDataSource.swift */; };
 		DBF1C554223D519C0080CADE /* TFLSettingsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBF1C553223D519C0080CADE /* TFLSettingsController.swift */; };
+		DBFAEA84272446C5005B9E21 /* UIFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBFAEA83272446C5005B9E21 /* UIFont.swift */; };
 		DBFCBB7C24B8B6AD00E3B3D3 /* Fonts.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBFCBB7B24B8B6AD00E3B3D3 /* Fonts.swift */; };
 /* End PBXBuildFile section */
 
@@ -217,6 +218,7 @@
 		DBF15BC82471CAB7004AA972 /* NetworkExtension.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NetworkExtension.framework; path = System/Library/Frameworks/NetworkExtension.framework; sourceTree = SDKROOT; };
 		DBF15EFC21597808006B0A58 /* NationalRailDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NationalRailDataSource.swift; sourceTree = "<group>"; };
 		DBF1C553223D519C0080CADE /* TFLSettingsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TFLSettingsController.swift; sourceTree = "<group>"; };
+		DBFAEA83272446C5005B9E21 /* UIFont.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIFont.swift; sourceTree = "<group>"; };
 		DBFCBB7B24B8B6AD00E3B3D3 /* Fonts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fonts.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -408,6 +410,7 @@
 				DB981489270887590029BA0A /* UnicodeExtensions.swift */,
 				D8293A0B26F787D3008CE13B /* URL.swift */,
 				D8D29BC92723E2F400125927 /* UIImage.swift */,
+				DBFAEA83272446C5005B9E21 /* UIFont.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -687,6 +690,7 @@
 				DBCA98B52144421F0084B710 /* DataSource.swift in Sources */,
 				D8DD98FC271EE98A004088CD /* UIApplication.swift in Sources */,
 				DB62F333224F89C200CA5E64 /* StationPickerController.swift in Sources */,
+				DBFAEA84272446C5005B9E21 /* UIFont.swift in Sources */,
 				D81DA7C02712953D0052D32C /* Localization.swift in Sources */,
 				D8C20D2B271CC1E600F3F22A /* FontLabelTableViewCell.swift in Sources */,
 				D8C20D2D271D2C8300F3F22A /* ValueRow.swift in Sources */,

--- a/ios/StatusPanel/BitmapFontLabel.swift
+++ b/ios/StatusPanel/BitmapFontLabel.swift
@@ -30,8 +30,17 @@ class BitmapFontLabel: UILabel {
     let maxFullSizeLines = Int.max
     var redactMode: RedactMode
 
-    init(frame: CGRect, font: Fonts.Font, scale: Int = 1, redactMode: RedactMode = .none) {
-        self.style = BitmapFontCache.Style(font: font.bitmapInfo!, scale: scale, darkMode: false)
+    init(frame: CGRect, bitmapFont: Fonts.BitmapInfo, scale: Int = 1, redactMode: RedactMode = .none) {
+        self.style = BitmapFontCache.Style(font: bitmapFont, scale: scale, darkMode: false)
+        self.redactMode = redactMode
+        super.init(frame: frame)
+        isAccessibilityElement = true
+        accessibilityTraits = UIAccessibilityTraits.staticText
+        isOpaque = false
+    }
+
+    init(frame: CGRect, uiFont: UIFont, redactMode: RedactMode = .none) {
+        self.style = BitmapFontCache.Style(uifont: uiFont, darkMode: false)
         self.redactMode = redactMode
         super.init(frame: frame)
         isAccessibilityElement = true
@@ -76,8 +85,9 @@ class BitmapFontLabel: UILabel {
         return lines
     }
 
-    private func getTextWidth<T>(_ text: T, forScale scale: Int? = nil) -> Int where T : StringProtocol {
-        let style = BitmapFontCache.Style(font: self.style.font, scale: scale ?? self.scale, darkMode: self.style.darkMode)
+    private func getTextWidth<T>(_ text: T, forScale newScale: Int? = nil) -> Int where T : StringProtocol {
+        let targetScale = newScale ?? self.scale
+        let style = targetScale == self.scale ? self.style : self.style.withScale(targetScale)
         return BitmapFontCache.shared.getTextWidth(text, forStyle: style)
     }
 
@@ -129,7 +139,7 @@ class BitmapFontLabel: UILabel {
         ctx.setFillColor(textColor.cgColor)
 
         // Dark mode may have changed, update style
-        self.style = BitmapFontCache.Style(font: self.style.font, scale: scale, darkMode: shouldUseDarkMode())
+        self.style = self.style.withDarkMode(shouldUseDarkMode())
 
         let lines = flow(text: self.text, width: self.bounds.width)
         let numFullsizeLines = min(lines.count, maxFullSizeLines)

--- a/ios/StatusPanel/Extensions/UIFont.swift
+++ b/ios/StatusPanel/Extensions/UIFont.swift
@@ -1,0 +1,58 @@
+// Copyright (c) 2018-2021 Jason Morley, Tom Sutcliffe
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import UIKit
+
+extension UIFont {
+
+    // Returns nil if the character does not appear in the font (ie does NOT do automatic fallback to any other font)
+    func renderCharacter(_ character: Character) -> CGImage? {
+        let font = self as CTFont
+        let ns = String(character) as NSString
+        let nchars = ns.length
+        var chars = Array<unichar>(repeating: 0, count: nchars)
+        ns.getCharacters(&chars, range: NSMakeRange(0, nchars))
+        var glyphs = Array<CGGlyph>(repeating: 0, count: nchars)
+        let ok = CTFontGetGlyphsForCharacters(self, chars, &glyphs, nchars)
+        if ok {
+            let descent = CTFontGetDescent(font)
+            // Drop any 0 glyphs, this can happen even if ok==true with non-BMP
+            // chars, because there's 2 UTF-16 unichars (ie a surrogate pair)
+            // that may map to only a single CGGlyph. Equally a single Character
+            // can map to multiple glyphs (eg a letter plus a combining accent)
+            glyphs = glyphs.compactMap { return $0 == 0 ? nil : $0 }
+            var glyphBounds = Array<CGRect>(repeating: .zero, count: glyphs.count)
+            let rect = CTFontGetOpticalBoundsForGlyphs(self, &glyphs, &glyphBounds, glyphs.count, .zero)
+            let img = CGImage.New(rect.size, flipped: true) { ctx in
+                ctx.setFillColor(UIColor.black.cgColor)
+                for i in 0 ..< glyphs.count {
+                    var transform = CGAffineTransform.init(translationX: glyphBounds[i].origin.x, y: descent)
+                    if let path = CTFontCreatePathForGlyph(font, glyphs[i], &transform) {
+                        ctx.addPath(path)
+                    }
+                }
+                ctx.drawPath(using: .fill)
+            }
+            return img
+        } else {
+            return nil
+        }
+    }
+}

--- a/ios/StatusPanel/View Controllers/ViewController.swift
+++ b/ios/StatusPanel/View Controllers/ViewController.swift
@@ -185,23 +185,22 @@ class ViewController: UIViewController, SettingsViewControllerDelegate {
     static func getLabel(frame: CGRect, font fontName: String, style: LabelStyle, redactMode: RedactMode = .none) -> UILabel {
         let font = Config().getFont(named: fontName)
         let size = (style == .header) ? font.headerSize : (style == .subText) ? font.subTextSize : font.textSize
-        if font.bitmapInfo != nil {
-            return BitmapFontLabel(frame: frame, font: font, scale: size, redactMode: redactMode)
-        } else {
-            let label = UILabel(frame: frame)
-            label.lineBreakMode = .byWordWrapping
-            if let uifont = UIFont(name: font.uifontName!, size: CGFloat(size)) {
-                label.font = uifont
-            } else {
-                print("No UIFont found for \(font.uifontName!)!")
-                for family in UIFont.familyNames {
-                    for fontName in UIFont.fontNames(forFamilyName: family) {
-                        print("Candidate: \(fontName)")
-                    }
-                }
-            }
-            return label
+        if let bitmapInfo = font.bitmapInfo {
+            return BitmapFontLabel(frame: frame, bitmapFont: bitmapInfo, scale: size, redactMode: redactMode)
+        } else if let uifont = UIFont(name: font.uifontName!, size: CGFloat(size)) {
+            return BitmapFontLabel(frame: frame, uiFont: uifont, redactMode: redactMode)
         }
+
+        // Otherwise, a plain old label (this code path now only used if we fail to find a font)
+        let label = UILabel(frame: frame)
+        label.lineBreakMode = .byWordWrapping
+        print("No UIFont found for \(font.uifontName!)!")
+        for family in UIFont.familyNames {
+            for fontName in UIFont.fontNames(forFamilyName: family) {
+                print("Candidate: \(fontName)")
+            }
+        }
+        return label
     }
 
     func renderAndUpload(data: [DataItemBase], completion: @escaping (Bool) -> Void) {


### PR DESCRIPTION
Using the same Unifont fallback process as for bitmap fonts. This also
makes redacted text work with TTF fonts.