### PR TITLE
fix(firmware): Update the service API URL

### DIFF
--- a/nodemcu/network.lua
+++ b/nodemcu/network.lua
@@ -23,7 +23,7 @@ function getImages()
         },
     }
 
-    local conn = http.createConnection("https://statuspanel.io/api/v2/"..deviceId, http.GET, options)
+    local conn = http.createConnection("https://api.statuspanel.io/api/v2/"..deviceId, http.GET, options)
     local f
     local result = {}
     conn:on("headers", function(status, headers)


### PR DESCRIPTION
We're planning to have a microsite at https://statuspanel.io, so this change moves the service to https://api.statuspanel.io before we get too many users 😅. The new URL is already and running, and in use by the iOS app.