### PR TITLE
ci: Don't require `realpath` when to bootstrap the firmware tool

### DIFF
--- a/scripts/firmware
+++ b/scripts/firmware
@@ -25,5 +25,5 @@ SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ROOT_DIR="${SCRIPTS_DIR}/.."
 NODEMCU_DIR="${ROOT_DIR}/nodemcu"
 
-export PIPENV_PIPFILE=$( realpath "${NODEMCU_DIR}/Pipfile" )
+export PIPENV_PIPFILE="${NODEMCU_DIR}/Pipfile"
 pipenv run python3 "${SCRIPTS_DIR}/${SCRIPT}.py" $@


### PR DESCRIPTION
The bootstrap bash scripts for tools should only rely on built-in commands to run.