### PR TITLE
refactor(ios): Common `UIImage` blank image factory

### DIFF
--- a/ios/StatusPanel/Extensions/UIImage.swift
+++ b/ios/StatusPanel/Extensions/UIImage.swift
@@ -52,6 +52,17 @@ class DataView {
 
 extension UIImage {
 
+    static func blankImage(size: CGSize, scale: CGFloat) -> UIImage {
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = scale
+        let renderer = UIGraphicsImageRenderer(size: Panel.size, format: format)
+        let image = renderer.image { context in
+            UIColor.white.setFill()
+            context.fill(CGRect(origin: .zero, size: Panel.size))
+        }
+        return image
+    }
+
     public func normalizeOrientation() -> UIImage? {
         UIGraphicsBeginImageContext(size)
         defer {

--- a/ios/StatusPanel/Utilities/Panel.swift
+++ b/ios/StatusPanel/Utilities/Panel.swift
@@ -26,6 +26,10 @@ class Panel {
     static let size = CGSize(width: 640.0, height: 384.0)
     static let statusBarHeight: CGFloat = 20.0
 
+    static func blankImage() -> UIImage {
+        return UIImage.blankImage(size: Panel.size, scale: 1.0)
+    }
+
     private static func ARGBtoPanel(_ data: Data) -> Data {
         let Black: UInt8 = 0, Colored: UInt8 = 1, White: UInt8 = 2
         var result = Data()

--- a/ios/StatusPanel/View Controllers/ViewController.swift
+++ b/ios/StatusPanel/View Controllers/ViewController.swift
@@ -170,7 +170,7 @@ class ViewController: UIViewController, SettingsViewControllerDelegate {
 
     func fetch() {
         dispatchPrecondition(condition: .onQueue(.main))
-        let blankImage = Self.blankPanelImage()
+        let blankImage = Panel.blankImage()
         self.imageView.image = blankImage
         self.image = blankImage
         self.redactedImage = blankImage
@@ -227,17 +227,6 @@ class ViewController: UIViewController, SettingsViewControllerDelegate {
 
     }
 
-    static func blankPanelImage() -> UIImage {
-        let fmt = UIGraphicsImageRendererFormat()
-        fmt.scale = 1.0
-        let renderer = UIGraphicsImageRenderer(size: Panel.size, format: fmt)
-        let uiImage = renderer.image { context in
-            UIColor.white.setFill()
-            context.fill(CGRect(origin: .zero, size: Panel.size))
-        }
-        return uiImage
-    }
-
     static func cropCustomRedactImageToPanelSize() -> UIImage {
         var path: URL?
         do {
@@ -248,12 +237,13 @@ class ViewController: UIViewController, SettingsViewControllerDelegate {
             path = dir.appendingPathComponent("customPrivacyImage.jpg")
         } catch {
             print("meh")
-            return blankPanelImage()
+            return Panel.blankImage()
         }
         guard let source = UIImage(contentsOfFile: path!.path)?
                 .normalizeOrientation()?
-                .scaleAndDither(to: Panel.size) else {
-            return blankPanelImage()
+                .scaleAndDither(to: Panel.size)
+        else {
+            return Panel.blankImage()
         }
         return source
     }


### PR DESCRIPTION
This change introduces a common `UIImage` blank image factory method and uses this to create a blank panel image when required. It also moves the `ViewController.blankPanelImage` method to the `Panel` class as this seems specific to the panel itself.