### PR TITLE
fix(ios): UI locks up when picking a privacy image

### DIFF
--- a/ios/StatusPanel.xcodeproj/project.pbxproj
+++ b/ios/StatusPanel.xcodeproj/project.pbxproj
@@ -12,6 +12,9 @@
 		D81252382709400E00C9D80A /* LicenseRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81252372709400E00C9D80A /* LicenseRow.swift */; };
 		D812523A2709403C00C9D80A /* LicenseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81252392709403C00C9D80A /* LicenseView.swift */; };
 		D812523C2709875600C9D80A /* FontPickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D812523B2709875600C9D80A /* FontPickerViewController.swift */; };
+		D8166551272773AC005BDA9E /* ImageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8166550272773AC005BDA9E /* ImageTableViewCell.swift */; };
+		D816655327277407005BDA9E /* UIActivityIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D816655227277407005BDA9E /* UIActivityIndicatorView.swift */; };
+		D816655527277632005BDA9E /* FileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D816655427277632005BDA9E /* FileManager.swift */; };
 		D81DA7C02712953D0052D32C /* Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81DA7BF2712953D0052D32C /* Localization.swift */; };
 		D81DA7C3271297460052D32C /* ZenQuotesDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81DA7C2271297460052D32C /* ZenQuotesDataSource.swift */; };
 		D81DE20326E19F9200504703 /* Clibsodium in Frameworks */ = {isa = PBXBuildFile; productRef = D81DE20226E19F9200504703 /* Clibsodium */; };
@@ -128,6 +131,9 @@
 		D81252372709400E00C9D80A /* LicenseRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LicenseRow.swift; sourceTree = "<group>"; };
 		D81252392709403C00C9D80A /* LicenseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LicenseView.swift; sourceTree = "<group>"; };
 		D812523B2709875600C9D80A /* FontPickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontPickerViewController.swift; sourceTree = "<group>"; };
+		D8166550272773AC005BDA9E /* ImageTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageTableViewCell.swift; sourceTree = "<group>"; };
+		D816655227277407005BDA9E /* UIActivityIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIActivityIndicatorView.swift; sourceTree = "<group>"; };
+		D816655427277632005BDA9E /* FileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileManager.swift; sourceTree = "<group>"; };
 		D81DA7BF2712953D0052D32C /* Localization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Localization.swift; sourceTree = "<group>"; };
 		D81DA7C2271297460052D32C /* ZenQuotesDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZenQuotesDataSource.swift; sourceTree = "<group>"; };
 		D82366EB2718B2D500086538 /* DatePickerTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatePickerTableViewCell.swift; sourceTree = "<group>"; };
@@ -385,10 +391,11 @@
 		D8D252B127146EB700C68EF9 /* Controls */ = {
 			isa = PBXGroup;
 			children = (
-				D8D252B227146ED800C68EF9 /* Value1TableViewCell.swift */,
 				D82366EB2718B2D500086538 /* DatePickerTableViewCell.swift */,
 				D8C20D2A271CC1E600F3F22A /* FontLabelTableViewCell.swift */,
+				D8166550272773AC005BDA9E /* ImageTableViewCell.swift */,
 				D8EBFCC7272099B0000E120F /* TextFieldTableViewCell.swift */,
+				D8D252B227146ED800C68EF9 /* Value1TableViewCell.swift */,
 			);
 			path = Controls;
 			sourceTree = "<group>";
@@ -404,13 +411,15 @@
 				D8E6D672271FBD3300AB6452 /* Color.swift */,
 				D8C20D22271C6C1500F3F22A /* EKCalendar.swift */,
 				D862BF3B271B98F90086BE48 /* String.swift */,
+				D816655227277407005BDA9E /* UIActivityIndicatorView.swift */,
 				D8DD98FB271EE98A004088CD /* UIApplication.swift */,
+				DBFAEA83272446C5005B9E21 /* UIFont.swift */,
+				D8D29BC92723E2F400125927 /* UIImage.swift */,
 				D83CC5212707543E00260DC1 /* UIStoryboard.swift */,
 				D89104842707B99F0020A2CF /* UIViewController.swift */,
 				DB981489270887590029BA0A /* UnicodeExtensions.swift */,
 				D8293A0B26F787D3008CE13B /* URL.swift */,
-				D8D29BC92723E2F400125927 /* UIImage.swift */,
-				DBFAEA83272446C5005B9E21 /* UIFont.swift */,
+				D816655427277632005BDA9E /* FileManager.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -642,6 +651,8 @@
 				D8AAC26726FA60D300215C1A /* CalendarHeaderSource.swift in Sources */,
 				DBCA98B12143F2B30084B710 /* TFLDataSource.swift in Sources */,
 				D8B98749270FF70F00EC2BA4 /* Binding+mappedToBool.swift in Sources */,
+				D816655327277407005BDA9E /* UIActivityIndicatorView.swift in Sources */,
+				D816655527277632005BDA9E /* FileManager.swift in Sources */,
 				DB6CE1472413AB4800FF1160 /* BitmapFontLabel.swift in Sources */,
 				D848A19A270D16AD00681F62 /* AddDataSourceView.swift in Sources */,
 				D8B3B3A827182BB000DD3148 /* AddDataSourceController.swift in Sources */,
@@ -691,6 +702,7 @@
 				D8DD98FC271EE98A004088CD /* UIApplication.swift in Sources */,
 				DB62F333224F89C200CA5E64 /* StationPickerController.swift in Sources */,
 				DBFAEA84272446C5005B9E21 /* UIFont.swift in Sources */,
+				D8166551272773AC005BDA9E /* ImageTableViewCell.swift in Sources */,
 				D81DA7C02712953D0052D32C /* Localization.swift in Sources */,
 				D8C20D2B271CC1E600F3F22A /* FontLabelTableViewCell.swift in Sources */,
 				D8C20D2D271D2C8300F3F22A /* ValueRow.swift in Sources */,

--- a/ios/StatusPanel/AppDelegate.swift
+++ b/ios/StatusPanel/AppDelegate.swift
@@ -27,6 +27,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
     var backgroundFetchCompletionFn : ((UIBackgroundFetchResult) -> Void)?
+    var config = Config()
     var sourceController = DataSourceController()
     var apnsToken: Data?
     var client: Client!
@@ -40,6 +41,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         client = Client(baseUrl: "https://api.statuspanel.io/")
         application.registerForRemoteNotifications()
+
+        do {
+            try config.migrate()
+        } catch {
+            print("Failed to migrate settings with error \(error)")
+        }
 
         let viewController = ViewController()
         let navigationController = UINavigationController(rootViewController: viewController)

--- a/ios/StatusPanel/Controls/ImageTableViewCell.swift
+++ b/ios/StatusPanel/Controls/ImageTableViewCell.swift
@@ -1,0 +1,55 @@
+// Copyright (c) 2018-2021 Jason Morley, Tom Sutcliffe
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import UIKit
+
+class ImageViewTableViewCell: UITableViewCell {
+
+    lazy var contentImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+
+    lazy var activityIndicatorView: UIActivityIndicatorView = {
+        let activityIndicatorView = UIActivityIndicatorView()
+        activityIndicatorView.translatesAutoresizingMaskIntoConstraints = false
+        return activityIndicatorView
+    }()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: .value1, reuseIdentifier: reuseIdentifier)
+        contentView.addSubview(contentImageView)
+        contentView.addSubview(activityIndicatorView)
+        NSLayoutConstraint.activate([
+            contentImageView.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor),
+            contentImageView.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor),
+            contentImageView.topAnchor.constraint(equalTo: contentView.layoutMarginsGuide.topAnchor),
+            contentImageView.bottomAnchor.constraint(equalTo: contentView.layoutMarginsGuide.bottomAnchor),
+            activityIndicatorView.centerXAnchor.constraint(equalTo: contentView.layoutMarginsGuide.centerXAnchor),
+            activityIndicatorView.centerYAnchor.constraint(equalTo: contentView.layoutMarginsGuide.centerYAnchor),
+        ])
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+}

--- a/ios/StatusPanel/Extensions/FileManager.swift
+++ b/ios/StatusPanel/Extensions/FileManager.swift
@@ -1,0 +1,33 @@
+// Copyright (c) 2018-2021 Jason Morley, Tom Sutcliffe
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+
+extension FileManager {
+
+    func documentsUrl() throws -> URL {
+        return try url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
+    }
+
+    func fileExists(at url: URL) -> Bool {
+        return fileExists(atPath: url.path)
+    }
+
+}

--- a/ios/StatusPanel/Extensions/UIActivityIndicatorView.swift
+++ b/ios/StatusPanel/Extensions/UIActivityIndicatorView.swift
@@ -1,0 +1,36 @@
+// Copyright (c) 2018-2021 Jason Morley, Tom Sutcliffe
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import UIKit
+
+extension UIActivityIndicatorView {
+
+    func setAnimating(_ animating: Bool) {
+        guard animating != isAnimating else {
+            return
+        }
+        if animating {
+            self.startAnimating()
+        } else {
+            self.stopAnimating()
+        }
+    }
+
+}

--- a/ios/StatusPanel/StatusPanelError.swift
+++ b/ios/StatusPanel/StatusPanelError.swift
@@ -30,6 +30,7 @@ enum StatusPanelError: Error {
     case unknownDataSource(DataSourceType)
     case internalInconsistency
     case incorrectSettingsType
+    case invalidImage
 
 }
 
@@ -53,6 +54,8 @@ extension StatusPanelError: LocalizedError {
             return LocalizedString("error_internal_inconsistency")
         case .incorrectSettingsType:
             return LocalizedString("error_incorrect_settings_type")
+        case .invalidImage:
+            return LocalizedString("error_invalid_image")
         }
     }
 

--- a/ios/StatusPanel/Utilities/Panel.swift
+++ b/ios/StatusPanel/Utilities/Panel.swift
@@ -30,6 +30,26 @@ class Panel {
         return UIImage.blankImage(size: Panel.size, scale: 1.0)
     }
 
+    static func privacyImage(from image: UIImage) throws -> UIImage? {
+        guard let source = image
+                .normalizeOrientation()?
+                .scaleAndDither(to: Panel.size)
+        else {
+            return nil
+        }
+        return source
+    }
+
+    static func privacyImage(from image: UIImage, completion: @escaping (Result<UIImage?, Error>) -> Void) {
+        DispatchQueue.global(qos: .userInteractive).async {
+            do {
+                completion(.success(try privacyImage(from: image)))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
     private static func ARGBtoPanel(_ data: Data) -> Data {
         let Black: UInt8 = 0, Colored: UInt8 = 1, White: UInt8 = 2
         var result = Data()
@@ -111,7 +131,7 @@ class Panel {
             let panelData = ARGBtoPanel(rawdata)
             let rleData = rleEncode(panelData)
             do {
-                let dir = try FileManager.default.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
+                let dir = try FileManager.default.documentsUrl()
                 print("GOT DIR! " + dir.absoluteString)
                 let imgdata = panelImage.pngData()
                 let name = "img_\(i)"

--- a/ios/StatusPanel/en-GB.lproj/Localizable.strings
+++ b/ios/StatusPanel/en-GB.lproj/Localizable.strings
@@ -26,6 +26,7 @@
 "error_unknown_data_source" = "Unknown data source (%@).";
 "error_internal_inconsistency" = "Internal inconsistency.";
 "error_incorrect_settings_type" = "Incorrect settings type.";
+"error_invalid_image" = "Invalid image.";
 
 "settings_last_background_update_label" = "Last Background Update";
 "settings_last_background_update_value_never" = "Never";

--- a/ios/StatusPanel/en.lproj/Localizable.strings
+++ b/ios/StatusPanel/en.lproj/Localizable.strings
@@ -26,6 +26,7 @@
 "error_unknown_data_source" = "Unknown data source (%@).";
 "error_internal_inconsistency" = "Internal inconsistency.";
 "error_incorrect_settings_type" = "Incorrect settings type.";
+"error_invalid_image" = "Invalid image.";
 
 "settings_last_background_update_label" = "Last Background Update";
 "settings_last_background_update_value_never" = "Never";


### PR DESCRIPTION
This change loads the privacy image on a background queue and shows a spinner when doing so. It also moves privacy image saving and loading into `Config` to match other settings and saves the pre-computed privacy image to avoid processing it every time.