### PR TITLE
fix(ios): Don't enable London Underground and National Rail content by default

### DIFF
--- a/ios/StatusPanel/Data/DataSourceController.swift
+++ b/ios/StatusPanel/Data/DataSourceController.swift
@@ -71,10 +71,6 @@ class DataSourceController {
                                                                 shortFormat: "yMMMMdEEE",
                                                                 offset: 0,
                                                                 flags: [.header, .spansColumns]))
-                try add(type: .transportForLondon,
-                        settings: TFLDataSource.Settings(lines: Set(config.activeTFLLines)))
-                try add(type: .nationalRail,
-                        settings: NationalRailDataSource.Settings(from: config.trainRoute.from, to: config.trainRoute.to))
                 try add(type: .calendar,
                         settings: CalendarSource.Settings(showLocations: config.showCalendarLocations,
                                                           showUrls: config.showUrlsInCalendarLocations,


### PR DESCRIPTION
This allows us to take users through the privacy screens for the National Rail and London Underground content when they first add them and draw their attention to the third-party privacy policies and details.