### PR TITLE
fix(ios): Image preview flashes when pulling 'Privacy Mode' view down

### DIFF
--- a/ios/StatusPanel/View Controllers/PrivacyModeController.swift
+++ b/ios/StatusPanel/View Controllers/PrivacyModeController.swift
@@ -27,6 +27,8 @@ class PrivacyModeController : UITableViewController, UINavigationControllerDeleg
 
     private let config: Config
 
+    private var firstRun = true
+
     private var privacyImage: UIImage? = nil {
         didSet {
             dispatchPrecondition(condition: .onQueue(.main))
@@ -51,6 +53,14 @@ class PrivacyModeController : UITableViewController, UINavigationControllerDeleg
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+        loadPrivacyImage()
+    }
+
+    func loadPrivacyImage() {
+        if !firstRun {
+            return
+        }
+        firstRun = false
         DispatchQueue.global(qos: .userInteractive).async {
             let image = try? self.config.privacyImage() ?? Panel.blankImage()
             DispatchQueue.main.async {


### PR DESCRIPTION
The privacy image preview was flashing when pulling the 'Privacy Mode' view controller down a little (as if to dismiss) because it was triggering a reload of the privacy image, even though it had already been loaded. This change guards that with a `firstRun` flag to prevent unnecessary loads and subsequent cross-fade animations (leading to the flash). Long-term (and especially if we ever switch this view to SwiftUI), we'll want to create a little privacy image manager that's responsible for explicitly publishing the loading state and performing the privacy image transform.