### PR TITLE
fix(ios): Over-dismissing the Add Device view controller

### DIFF
--- a/ios/StatusPanel/View Controllers/AddViewController.swift
+++ b/ios/StatusPanel/View Controllers/AddViewController.swift
@@ -67,10 +67,7 @@ extension AddViewController: QRCodeViewConrollerDelegate {
     }
 
     func qrCodeViewControllerDidCancel(_ qrCodeViewController: QRCodeViewController) {
-        dismiss(animated: true) {
-            self.addDelegate?.addViewControllerDidCancel(self)
-        }
-
+        self.addDelegate?.addViewControllerDidCancel(self)
     }
 
 }


### PR DESCRIPTION
`AddViewController` shouldn't dismiss itself; this is left up to its owner.