### PR TITLE
fix(ios): Update 'About StatusPanel' button text

### DIFF
--- a/ios/StatusPanel/View Controllers/SettingsViewController.swift
+++ b/ios/StatusPanel/View Controllers/SettingsViewController.swift
@@ -321,8 +321,7 @@ class SettingsViewController: UITableViewController, UIAdaptivePresentationContr
             return cell
         case AboutSection:
             let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
-            cell.textLabel?.text = "About StatusPanel"
-            cell.textLabel?.textColor = UIColor(named: "TintColor")
+            cell.textLabel?.text = "About StatusPanel..."
             return cell
         default:
             return UITableViewCell(style: .default, reuseIdentifier: nil)


### PR DESCRIPTION
The 'About StatusPanel' button in settings should follow the convention that an ellipsis is used whenever a new sheet will be presented.