### PR TITLE
feat(service): Support UUID identifiers

### DIFF
--- a/service/app.py
+++ b/service/app.py
@@ -63,11 +63,18 @@ def close_database(exception):
         db.close()
 
 
+# Valid identifiers are either 8-character strings comprising 0-9 and a-z, or
+# canonical UUID strings (hex digits structured as 8-4-4-4-12).
+SHORT_IDENTIFIER_REGEX = r"^[0-9a-z]{8}$"
+UUID_IDENTIFIER_REGEX = r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+
+
 def check_identifier(fn):
     @functools.wraps(fn)
     def inner(*args, **kwargs):
         logging.info(f"Checking identifier '{kwargs['identifier']}'...")
-        if not re.match(r"^[0-9a-z]{8}$", kwargs['identifier']):
+        if (not re.match(SHORT_IDENTIFIER_REGEX, kwargs['identifier']) and
+            not re.match(UUID_IDENTIFIER_REGEX, kwargs['identifier'])):
             request.stream.read()
             return f"Invalid identifier '{kwargs['identifier']}'", 400
         return fn(*args, **kwargs)

--- a/service/tests/test_api.py
+++ b/service/tests/test_api.py
@@ -26,6 +26,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import uuid
 import unittest
 import urllib
 
@@ -189,6 +190,26 @@ class TestAPI(unittest.TestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200, "Getting the uploaded file succeeds")
         self.assertEqual(response.content, data_2, "Downloaded file matches uploaded file")
+
+    def test_api_v2_uuid_identifier_put_get_success(self):
+        identifier = str(uuid.uuid4())
+        url = '/api/v2/' + identifier
+        data = os.urandom(307200)
+        response = self._upload(url, data)
+        self.assertEqual(response.status_code, 200, "Upload succeeds")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, "Getting the uploaded file succeeds")
+        self.assertEqual(response.content, data, "Downloaded file matches uploaded file")
+
+    def test_api_v3_uuid_identifier_put_get_success(self):
+        identifier = str(uuid.uuid4())
+        url = '/api/v3/status/' + identifier
+        data = os.urandom(307200)
+        response = self._upload(url, data)
+        self.assertEqual(response.status_code, 200, "Upload succeeds")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, "Getting the uploaded file succeeds")
+        self.assertEqual(response.content, data, "Downloaded file matches uploaded file")
 
     def _test_put_get_last_modified(self, url):
         data = os.urandom(307200)


### PR DESCRIPTION
This change is intended to make it easier to generate good unique identifiers for devices by allowing canonical UUIDs as identifiers.