### PR TITLE
fix(mac-simulator): Generate unique identifiers for each simulator instance

### DIFF
--- a/simulator/StatusPanel Simulator/ContentView.swift
+++ b/simulator/StatusPanel Simulator/ContentView.swift
@@ -39,11 +39,14 @@ struct ContentView: View {
             .frame(width: CGFloat(Device.v1.width), height: CGFloat(Device.v1.height))
             .background(.white)
             .padding()
+            if let identifier = applicationModel.identifier {
+                LabeledContent("Identifier", value: identifier.id.uuidString)
+            }
             if let update = applicationModel.lastUpdate {
                 LabeledContent("Wakeup Time", value: String(update.wakeupTime))
-                    .foregroundColor(.secondary)
             }
         }
+        .textSelection(.enabled)
         .toolbar(id: "main") {
             ToolbarItem(id: "action") {
                 Button {

--- a/simulator/StatusPanel Simulator/DeviceIdentifier.swift
+++ b/simulator/StatusPanel Simulator/DeviceIdentifier.swift
@@ -24,7 +24,20 @@ import Sodium
 
 struct DeviceIdentifier {
 
-    let id: String
+    let id: UUID
     let keyPair: Box.KeyPair
+
+    var pairingURL: URL {
+        let sodium = Sodium()
+        let publicKeyBase64 = sodium.utils.bin2base64(keyPair.publicKey, variant: .ORIGINAL)!
+        var components = URLComponents()
+        components.scheme = "statuspanel"
+        components.path = "r2"
+        components.queryItems = [
+            URLQueryItem(name: "id", value: id.uuidString),
+            URLQueryItem(name: "pk", value: publicKeyBase64),
+        ]
+        return components.url!
+    }
 
 }

--- a/simulator/StatusPanel Simulator/Service.swift
+++ b/simulator/StatusPanel Simulator/Service.swift
@@ -33,8 +33,8 @@ struct Service {
 
     static func update(identifier: DeviceIdentifier) async throws -> Update {
 
-        let url = URL(string: "https://api.statuspanel.io/api/v2")!
-            .appendingPathComponent(identifier.id)
+        let url = URL(string: "https://api.statuspanel.io/api/v3/status")!
+            .appendingPathComponent(identifier.id.uuidString)
 
         let response = try await URLSession.shared.data(from: url)
         let data = response.0


### PR DESCRIPTION
This change also includes a drive-by fix to use the new v3 endpoint.