### PR TITLE
ci: Rename website build job

### DIFF
--- a/.github/workflows/build-website.yaml
+++ b/.github/workflows/build-website.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
 
-  run:
+  build-website:
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/build-website.yaml
+++ b/.github/workflows/build-website.yaml
@@ -24,7 +24,7 @@ jobs:
         fetch-depth: 0
 
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: "3.9"
 

--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,6 @@ _site
 .jekyll-cache
 
 # Website
-/docs/simulator
-/docs/release-notes
+# Right now we can't actually ignore these as there's no way to force add them using git-auto-commit.
+# /docs/simulator
+# /docs/release-notes


### PR DESCRIPTION
This includes a drive-by fix to ensure we actually deploy the simulator in website builds.