### PR TITLE
fix(simulator-mac): Use the project accent color for the panel highlight color

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -45,7 +45,8 @@ Images are transmitted in a 2BPP format, encrypted using a [libsodium sealed box
 Image values are as follows:
 
 - `0` – black
-- `1` – white
+- `1` – highlight color
+- `2` – white
 
 ## Possible Attack Vectors
 

--- a/simulator/StatusPanel Simulator/Extensions/Data.swift
+++ b/simulator/StatusPanel Simulator/Extensions/Data.swift
@@ -47,7 +47,7 @@ extension Data {
 
         let colorMap: [UInt8: UInt32] = [
             0: 0x000000FF,
-            1: 0xFFFF00FF,
+            1: 0x7FFFD4FF,
             2: 0xFFFFFFFF,
         ]
 


### PR DESCRIPTION
This includes a drive-by documentation fix to clarify the pixel color values.