### PR TITLE
fix(ios): Disable National Rail data source

### DIFF
--- a/ios/StatusPanel/Data/DataSourceController.swift
+++ b/ios/StatusPanel/Data/DataSourceController.swift
@@ -42,7 +42,6 @@ class DataSourceController {
             CalendarSource().anyDataSource(),
             CalendarHeaderSource().anyDataSource(),
             DummyDataSource().anyDataSource(),
-            NationalRailDataSource(configuration: configuration).anyDataSource(),
             TextDataSource().anyDataSource(),
             TFLDataSource(configuration: configuration).anyDataSource(),
             ZenQuotesDataSource().anyDataSource(),


### PR DESCRIPTION
Unfortunately the National Rail proxy we were using is no longer supported; disabling until we have an alternative.