### PR TITLE
refactor(ios): Move rendering out of `ViewController`

### DIFF
--- a/ios/StatusPanel.xcodeproj/project.pbxproj
+++ b/ios/StatusPanel.xcodeproj/project.pbxproj
@@ -59,6 +59,10 @@
 		D8DAED7226E3F3320002F388 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8DAED7126E3F3320002F388 /* Configuration.swift */; };
 		D8DAED7426E3F3930002F388 /* StatusPanelError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8DAED7326E3F3930002F388 /* StatusPanelError.swift */; };
 		D8DAED7726E3F3D40002F388 /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8DAED7626E3F3D40002F388 /* Bundle.swift */; };
+		D8DCA7D629CBEA92002010A5 /* LabelStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8DCA7D529CBEA92002010A5 /* LabelStyle.swift */; };
+		D8DCA7DA29CBEB43002010A5 /* Renderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8DCA7D929CBEB42002010A5 /* Renderer.swift */; };
+		D8DCA7DC29CBEBDD002010A5 /* RedactMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8DCA7DB29CBEBDD002010A5 /* RedactMode.swift */; };
+		D8DCA7DE29CBEE4D002010A5 /* UILabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8DCA7DD29CBEE4D002010A5 /* UILabel.swift */; };
 		D8DD98FF271EF8CD004088CD /* ColoredCheckbox.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8DD98FE271EF8CD004088CD /* ColoredCheckbox.swift */; };
 		D8DD9901271EF971004088CD /* Binding.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8DD9900271EF971004088CD /* Binding.swift */; };
 		D8E285AD271A4547001738A8 /* ExternalOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E285AC271A4547001738A8 /* ExternalOperation.swift */; };
@@ -178,6 +182,10 @@
 		D8DC8D7E26E1ADAF004B081D /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		D8DC8D7F26E1ADAF004B081D /* Common.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Common.xcconfig; sourceTree = "<group>"; };
 		D8DC8D8026E1ADAF004B081D /* Release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
+		D8DCA7D529CBEA92002010A5 /* LabelStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelStyle.swift; sourceTree = "<group>"; };
+		D8DCA7D929CBEB42002010A5 /* Renderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Renderer.swift; sourceTree = "<group>"; };
+		D8DCA7DB29CBEBDD002010A5 /* RedactMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedactMode.swift; sourceTree = "<group>"; };
+		D8DCA7DD29CBEE4D002010A5 /* UILabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UILabel.swift; sourceTree = "<group>"; };
 		D8DD98FE271EF8CD004088CD /* ColoredCheckbox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColoredCheckbox.swift; sourceTree = "<group>"; };
 		D8DD9900271EF971004088CD /* Binding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Binding.swift; sourceTree = "<group>"; };
 		D8E285AC271A4547001738A8 /* ExternalOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalOperation.swift; sourceTree = "<group>"; };
@@ -325,6 +333,7 @@
 				D89104862707BAD50020A2CF /* DataSourceInstance.swift */,
 				D8383EBD270FBA1B0007EBB7 /* DataSourceSettingsStore.swift */,
 				D8E6839B270DF11800504B5E /* DataSourceType.swift */,
+				D8DCA7D529CBEA92002010A5 /* LabelStyle.swift */,
 				D842A3FC265BE81F009C1156 /* Calendar */,
 				D89104882707BB3D0020A2CF /* Dummy */,
 				D842A3FE265BE878009C1156 /* National Rail */,
@@ -419,14 +428,15 @@
 				DB17F92E249E3BAD008CD83E /* CGExtensions.swift */,
 				D8E6D672271FBD3300AB6452 /* Color.swift */,
 				D8C20D22271C6C1500F3F22A /* EKCalendar.swift */,
+				D816655427277632005BDA9E /* FileManager.swift */,
 				D816655227277407005BDA9E /* UIActivityIndicatorView.swift */,
 				DBFAEA83272446C5005B9E21 /* UIFont.swift */,
 				D8D29BC92723E2F400125927 /* UIImage.swift */,
+				D8DCA7DD29CBEE4D002010A5 /* UILabel.swift */,
 				D83CC5212707543E00260DC1 /* UIStoryboard.swift */,
 				D89104842707B99F0020A2CF /* UIViewController.swift */,
 				DB981489270887590029BA0A /* UnicodeExtensions.swift */,
 				D8293A0B26F787D3008CE13B /* URL.swift */,
-				D816655427277632005BDA9E /* FileManager.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -490,6 +500,8 @@
 				D8E285AE271A45CE001738A8 /* Device.swift */,
 				DBFCBB7B24B8B6AD00E3B3D3 /* Fonts.swift */,
 				D8D98E422493019A00F853CA /* NetworkProvisioner.swift */,
+				D8DCA7DB29CBEBDD002010A5 /* RedactMode.swift */,
+				D8DCA7D929CBEB42002010A5 /* Renderer.swift */,
 				D8DAED7326E3F3930002F388 /* StatusPanelError.swift */,
 				DB5E9DA0241562ED009F3807 /* StringUtils.swift */,
 				DBCA98832143E2920084B710 /* Assets.xcassets */,
@@ -499,12 +511,12 @@
 				DBCA98852143E2920084B710 /* LaunchScreen.storyboard */,
 				D862BF3D271B99450086BE48 /* Licenses */,
 				D8C20D20271C2A6200F3F22A /* Localizable.strings */,
+				D816655A2727B7D1005BDA9E /* Localizable.stringsdict */,
 				DBCA987A2143E2920084B710 /* Products */,
 				D8DD98FD271EF8A8004088CD /* Styles */,
 				D81DA7BE2712952D0052D32C /* Utilities */,
 				D842A401265BE916009C1156 /* View Controllers */,
 				D812523427093BAB00C9D80A /* Views */,
-				D816655A2727B7D1005BDA9E /* Localizable.stringsdict */,
 			);
 			path = StatusPanel;
 			sourceTree = "<group>";
@@ -665,13 +677,16 @@
 				D848A19A270D16AD00681F62 /* AddDataSourceView.swift in Sources */,
 				D8B3B3A827182BB000DD3148 /* AddDataSourceController.swift in Sources */,
 				D8C20D27271C7A6E00F3F22A /* CalendarPickerController.swift in Sources */,
+				D8DCA7D629CBEA92002010A5 /* LabelStyle.swift in Sources */,
 				D8E6D673271FBD3300AB6452 /* Color.swift in Sources */,
+				D8DCA7DE29CBEE4D002010A5 /* UILabel.swift in Sources */,
 				D848A198270C8DB100681F62 /* TextDataSource.swift in Sources */,
 				D8DAED7226E3F3320002F388 /* Configuration.swift in Sources */,
 				D81DA7C3271297460052D32C /* ZenQuotesDataSource.swift in Sources */,
 				D8CC37B12717887A00938C5D /* Panel.swift in Sources */,
 				D8E6839C270DF11800504B5E /* DataSourceType.swift in Sources */,
 				DB3E769F2416CD9E000D059A /* DarkModeController.swift in Sources */,
+				D8DCA7DA29CBEB43002010A5 /* Renderer.swift in Sources */,
 				D8D29BCA2723E2F400125927 /* UIImage.swift in Sources */,
 				D8DAED7426E3F3930002F388 /* StatusPanelError.swift in Sources */,
 				D8D252B327146ED800C68EF9 /* Value1TableViewCell.swift in Sources */,
@@ -713,6 +728,7 @@
 				D8383EC0270FC50A0007EBB7 /* FormatEditor.swift in Sources */,
 				DBCA987D2143E2920084B710 /* AppDelegate.swift in Sources */,
 				D89104872707BAD50020A2CF /* DataSourceInstance.swift in Sources */,
+				D8DCA7DC29CBEBDD002010A5 /* RedactMode.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/StatusPanel/BitmapFontLabel.swift
+++ b/ios/StatusPanel/BitmapFontLabel.swift
@@ -21,10 +21,6 @@
 import UIKit
 import CoreImage
 
-enum RedactMode {
-    case none, redactLines, redactWords
-}
-
 class BitmapFontLabel: UILabel {
     var style: BitmapFontCache.Style
     let maxFullSizeLines = Int.max

--- a/ios/StatusPanel/Config.swift
+++ b/ios/StatusPanel/Config.swift
@@ -430,6 +430,17 @@ class Config {
         }
     }
 
+    var displaysInDarkMode: Bool {
+        switch darkMode {
+        case .off:
+            return false
+        case .on:
+            return true
+        case .system:
+            return UITraitCollection.current.userInterfaceStyle == UIUserInterfaceStyle.dark
+        }
+    }
+
     var showDummyData: Bool {
         get {
             self.bool(for: .dummyData)

--- a/ios/StatusPanel/Data/DataSource.swift
+++ b/ios/StatusPanel/Data/DataSource.swift
@@ -66,6 +66,14 @@ struct DataItemFlags: OptionSet, Codable {
     static let header = DataItemFlags(rawValue: 1 << 1)
     static let prefersEmptyColumn = DataItemFlags(rawValue: 1 << 2)
     static let spansColumns = DataItemFlags(rawValue: 1 << 3)
+
+    var labelStyle: LabelStyle {
+        if contains(.header) {
+            return .header
+        }
+        return .text
+    }
+    
 }
 
 protocol DataItemBase : AnyObject {

--- a/ios/StatusPanel/Data/LabelStyle.swift
+++ b/ios/StatusPanel/Data/LabelStyle.swift
@@ -18,33 +18,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import UIKit
+import Foundation
 
-class FontLabelTableViewCell: UITableViewCell {
-
-    let labelFont: Fonts.Font
-    let redactMode: RedactMode
-
-    lazy var label: UILabel = {
-        let label = UILabel.getLabel(frame: .zero, font: labelFont.configName, style: .text, redactMode: redactMode)
-        label.translatesAutoresizingMaskIntoConstraints = false
-        return label
-    }()
-
-    init(font: Fonts.Font, redactMode: RedactMode = .none) {
-        self.labelFont = font
-        self.redactMode = redactMode
-        super.init(style: .default, reuseIdentifier: nil)
-        contentView.addSubview(label)
-        NSLayoutConstraint.activate([
-            label.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
-            label.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor),
-            label.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor),
-        ])
-    }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
+enum LabelStyle {
+    case text
+    case header
+    case subText
 }

--- a/ios/StatusPanel/Extensions/UILabel.swift
+++ b/ios/StatusPanel/Extensions/UILabel.swift
@@ -1,0 +1,50 @@
+// Copyright (c) 2018-2023 Jason Morley, Tom Sutcliffe
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import UIKit
+
+extension UILabel {
+
+    static func getLabel(frame: CGRect,
+                         font fontName: String,
+                         style: LabelStyle,
+                         redactMode: RedactMode = .none) -> UILabel {
+        dispatchPrecondition(condition: .onQueue(.main))
+        let font = Config().getFont(named: fontName)
+        let size = (style == .header) ? font.headerSize : (style == .subText) ? font.subTextSize : font.textSize
+        if let bitmapInfo = font.bitmapInfo {
+            return BitmapFontLabel(frame: frame, bitmapFont: bitmapInfo, scale: size, redactMode: redactMode)
+        } else if let uifont = UIFont(name: font.uifontName!, size: CGFloat(size)) {
+            return BitmapFontLabel(frame: frame, uiFont: uifont, redactMode: redactMode)
+        }
+
+        // Otherwise, a plain old label (this code path now only used if we fail to find a font)
+        let label = UILabel(frame: frame)
+        label.lineBreakMode = .byWordWrapping
+        print("No UIFont found for \(font.uifontName!)!")
+        for family in UIFont.familyNames {
+            for fontName in UIFont.fontNames(forFamilyName: family) {
+                print("Candidate: \(fontName)")
+            }
+        }
+        return label
+    }
+
+}

--- a/ios/StatusPanel/RedactMode.swift
+++ b/ios/StatusPanel/RedactMode.swift
@@ -18,33 +18,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import UIKit
+import Foundation
 
-class FontLabelTableViewCell: UITableViewCell {
-
-    let labelFont: Fonts.Font
-    let redactMode: RedactMode
-
-    lazy var label: UILabel = {
-        let label = UILabel.getLabel(frame: .zero, font: labelFont.configName, style: .text, redactMode: redactMode)
-        label.translatesAutoresizingMaskIntoConstraints = false
-        return label
-    }()
-
-    init(font: Fonts.Font, redactMode: RedactMode = .none) {
-        self.labelFont = font
-        self.redactMode = redactMode
-        super.init(style: .default, reuseIdentifier: nil)
-        contentView.addSubview(label)
-        NSLayoutConstraint.activate([
-            label.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
-            label.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor),
-            label.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor),
-        ])
-    }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
+enum RedactMode {
+    case none
+    case redactLines
+    case redactWords
 }

--- a/ios/StatusPanel/Renderer.swift
+++ b/ios/StatusPanel/Renderer.swift
@@ -1,0 +1,208 @@
+// Copyright (c) 2018-2023 Jason Morley, Tom Sutcliffe
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+import UIKit
+
+struct Renderer {
+
+    private enum DividerStyle {
+        case vertical(originY: CGFloat)
+        case horizontal(originY: CGFloat)
+    }
+
+    static func render(data: [DataItemBase], config: Config) -> [UIImage] {
+        dispatchPrecondition(condition: .onQueue(.main))
+        let image = renderImage(data: data, config: config)
+        let privacyImage = renderPrivacyImage(data: data, config: config)
+        return [image, privacyImage]
+    }
+
+    private static func renderImage(data: [DataItemBase],
+                                    config: Config,
+                                    redact: Bool = false) -> UIImage {
+        dispatchPrecondition(condition: .onQueue(.main))
+
+        let contentView = UIView(frame: CGRect(origin: .zero, size: Panel.size))
+        contentView.contentScaleFactor = 1.0
+
+        // Construct the contentView's contents. For now just make labels and flow them into 2 columns
+        contentView.backgroundColor = config.displaysInDarkMode ? UIColor.black : UIColor.white
+        let foregroundColor = config.displaysInDarkMode ? UIColor.white : UIColor.black
+        let twoCols = config.displayTwoColumns
+        let showIcons = config.showIcons
+        let rect = contentView.frame
+        let maxy = rect.height - 10 // Leave space for status line
+        let midx = rect.width / 2
+        var x : CGFloat = 5
+        var y : CGFloat = 0
+        let colWidth = twoCols ? (rect.width / 2 - x * 2) : rect.width - x
+        let bodyFont = config.getFont(named: config.bodyFont)
+        let itemGap = CGFloat(min(10, bodyFont.textHeight / 2)) // ie 50% of the body text line height up to a max of 10px
+        var colStart = y
+        var col = 0
+        var columnItemCount = 0 // Number of items assigned to the current column
+        var divider: DividerStyle? = twoCols ? .vertical(originY: 0) : nil
+        let redactMode: RedactMode = (redact ? (config.privacyMode == .redactWords ? .redactWords : .redactLines) : .none)
+
+        for item in data {
+
+            let flags = item.flags
+            let font = flags.contains(.header) ? config.titleFont : config.bodyFont
+            let fontDetails = Config().getFont(named: font)
+            let w = flags.contains(.spansColumns) ? rect.width : colWidth
+            let frame = CGRect(x: x, y: y, width: w, height: 0)
+            let view = UIView(frame: frame)
+            var prefix = fontDetails.supportsEmoji && showIcons ? item.iconAndPrefix : item.prefix
+            let numPrefixLines = prefix.split(separator: "\n").count
+            var textFrame = CGRect(origin: CGPoint.zero, size: frame.size)
+            var itemHeight: CGFloat = 0
+
+            if !prefix.isEmpty {
+                let prefixLabel = UILabel.getLabel(frame: textFrame,
+                                                   font: font,
+                                                   style: flags.labelStyle,
+                                                   redactMode: redactMode)
+                prefixLabel.textColor = foregroundColor
+                prefixLabel.numberOfLines = numPrefixLines
+                prefixLabel.text = prefix + " "
+                prefixLabel.sizeToFit()
+                let prefixWidth = prefixLabel.frame.width
+                if prefixWidth < frame.width / 2 {
+                    prefix = ""
+                    view.addSubview(prefixLabel)
+                    textFrame = textFrame.divided(atDistance: prefixWidth, from: .minXEdge).remainder
+                    itemHeight = prefixLabel.frame.height
+                } else {
+                    // Label too long, treat as single text entity (leave 'prefix' set)
+                    prefix = prefix + " "
+                }
+            }
+            let label = UILabel.getLabel(frame: textFrame,
+                                         font: font,
+                                         style: flags.labelStyle,
+                                         redactMode: redactMode)
+            label.numberOfLines = 1 // Temporarily while we're using it in checkFit
+
+            let text = prefix + item.getText(checkFit: { (string: String) -> Bool in
+                label.text = prefix + string
+                let size = label.sizeThatFits(textFrame.size)
+                return size.width <= textFrame.width
+            })
+            label.textColor = foregroundColor
+            if flags.contains(.warning) {
+                // Icons don't render well on the panel, use a coloured background instead
+                label.backgroundColor = UIColor.yellow
+                label.textColor = UIColor.black
+            }
+            label.numberOfLines = config.maxLines
+            label.lineBreakMode = .byTruncatingTail
+            label.text = text
+            label.sizeToFit()
+            itemHeight = max(itemHeight, label.bounds.height)
+            label.frame = CGRect(x: label.frame.minX,
+                                 y: label.frame.minY,
+                                 width: textFrame.width,
+                                 height: label.frame.height)
+            view.frame = CGRect(origin: view.frame.origin, size: CGSize(width: view.frame.width, height: itemHeight))
+            view.addSubview(label)
+            if let subText = item.subText {
+                let subLabel = UILabel.getLabel(frame: textFrame,
+                                                font: font,
+                                                style: .subText,
+                                                redactMode: redactMode)
+                subLabel.textColor = foregroundColor
+                subLabel.numberOfLines = config.maxLines
+                subLabel.text = subText
+                subLabel.sizeToFit()
+                subLabel.frame = CGRect(x: textFrame.minX, y: view.bounds.maxY + 1, width: textFrame.width, height: subLabel.frame.height)
+                view.frame = CGRect(origin: view.frame.origin, size: CGSize(width: view.frame.width, height: subLabel.frame.maxY))
+                view.addSubview(subLabel)
+            }
+            let sz = view.frame
+            // Enough space for this item?
+            let itemIsColBreak = (columnItemCount > 0 && flags.contains(.prefersEmptyColumn))
+            if (col == 0 && twoCols && (sz.height > maxy - y || itemIsColBreak)) {
+                // overflow to 2nd column
+                col += 1
+                columnItemCount = 0
+                x += midx + 5
+                y = colStart
+                view.frame = CGRect(x: x, y: y, width: sz.width, height: sz.height)
+            } else if (!twoCols && itemIsColBreak) {
+                // Leave some extra space and mark where to draw a line
+                divider = .horizontal(originY: y)
+                let c = view.center
+                view.center = CGPoint(x: c.x, y: c.y + itemGap)
+                y += itemGap
+            }
+            contentView.addSubview(view)
+
+            y = y + sz.height + itemGap
+
+            if flags.contains(.spansColumns) {
+                // Update the verticial origin of the divider and columns, and start at column 0 again.
+                divider = .vertical(originY: y)
+                colStart = y
+                columnItemCount = 0
+                col = 0
+            } else {
+                // Track the number of items in the current column.
+                columnItemCount += 1
+            }
+
+        }
+
+        // And render it into an image
+        let result = UIImage.New(rect.size, flipped: false) { context in
+            // layer.render() works when the device is locked, whereas drawHierarchy() doesn't
+            contentView.layer.render(in: context)
+
+            // Draw the dividing line.
+            if let divider = divider {
+
+                context.setStrokeColor(foregroundColor.cgColor)
+                context.beginPath()
+
+                switch divider {
+                case .vertical(let originY):
+                    context.move(to: CGPoint(x: midx, y: originY))
+                    context.addLine(to: CGPoint(x: midx, y: rect.height - Panel.statusBarHeight))
+                case .horizontal(let originY):
+                    context.move(to: CGPoint(x: x, y: originY))
+                    context.addLine(to: CGPoint(x: rect.width - x, y: originY))
+                }
+
+                context.drawPath(using: .stroke)
+            }
+        }
+        return result
+    }
+
+    private static func renderPrivacyImage(data: [DataItemBase], config: Config) -> UIImage {
+        switch config.privacyMode {
+        case .redactLines, .redactWords:
+            return renderImage(data: data, config: config, redact: true)
+        case .customImage:
+            return (try? config.privacyImage()) ?? Panel.blankImage()
+        }
+    }
+
+}

--- a/ios/StatusPanel/View Controllers/SettingsViewController.swift
+++ b/ios/StatusPanel/View Controllers/SettingsViewController.swift
@@ -279,7 +279,7 @@ class SettingsViewController: UITableViewController, UIAdaptivePresentationContr
             let config = Config()
             let fontName = indexPath.row == 0 ? config.titleFont : config.bodyFont
             let font = config.getFont(named: fontName)
-            let fontLabel = ViewController.getLabel(frame: .zero, font: font.configName, style: .text)
+            let fontLabel = UILabel.getLabel(frame: .zero, font: font.configName, style: .text)
             fontLabel.text = font.humanReadableName
             fontLabel.translatesAutoresizingMaskIntoConstraints = false
             fontLabel.textColor = .secondaryLabel

--- a/ios/StatusPanel/View Controllers/ViewController.swift
+++ b/ios/StatusPanel/View Controllers/ViewController.swift
@@ -21,36 +21,10 @@
 import UIKit
 import EventKit
 
-import Sodium
-
-extension DataItemFlags {
-
-    var labelStyle: ViewController.LabelStyle {
-        if contains(.header) {
-            return .header
-        }
-        return .text
-    }
-
-}
-
 class ViewController: UIViewController, SettingsViewControllerDelegate {
-
-    enum DividerStyle {
-        case vertical(originY: CGFloat)
-        case horizontal(originY: CGFloat)
-    }
-
-    enum LabelStyle {
-        case text
-        case header
-        case subText
-    }
 
     private var image: UIImage?
     private var redactedImage: UIImage?
-
-    let SettingsButtonTag = 1
 
     var sourceController: DataSourceController!
 
@@ -94,17 +68,6 @@ class ViewController: UIViewController, SettingsViewControllerDelegate {
         gestureRecognizer.minimumPressDuration = 0
         return gestureRecognizer
     }()
-
-    private var showRedacted: Bool = false {
-        didSet {
-            switch showRedacted {
-            case true:
-                imageView.image = redactedImage
-            case false:
-                imageView.image = image
-            }
-        }
-    }
 
     init() {
         super.init(nibName: nil, bundle: nil)
@@ -209,38 +172,14 @@ class ViewController: UIViewController, SettingsViewControllerDelegate {
         self.refreshButtonItem.isEnabled = true
     }
 
-    static func getLabel(frame: CGRect, font fontName: String, style: LabelStyle, redactMode: RedactMode = .none) -> UILabel {
-        let font = Config().getFont(named: fontName)
-        let size = (style == .header) ? font.headerSize : (style == .subText) ? font.subTextSize : font.textSize
-        if let bitmapInfo = font.bitmapInfo {
-            return BitmapFontLabel(frame: frame, bitmapFont: bitmapInfo, scale: size, redactMode: redactMode)
-        } else if let uifont = UIFont(name: font.uifontName!, size: CGFloat(size)) {
-            return BitmapFontLabel(frame: frame, uiFont: uifont, redactMode: redactMode)
-        }
-
-        // Otherwise, a plain old label (this code path now only used if we fail to find a font)
-        let label = UILabel(frame: frame)
-        label.lineBreakMode = .byWordWrapping
-        print("No UIFont found for \(font.uifontName!)!")
-        for family in UIFont.familyNames {
-            for fontName in UIFont.fontNames(forFamilyName: family) {
-                print("Candidate: \(fontName)")
-            }
-        }
-        return label
-    }
-
     func renderAndUpload(data: [DataItemBase], completion: @escaping (Bool) -> Void) {
-        let darkMode = shouldBeDark()
-        let image = Self.renderToImage(data: data, shouldRedact: false, darkMode: darkMode)
-
-        let privacyImage = ((Config().privacyMode == .customImage)
-                            ? ViewController.loadPrivacyImage()
-                            : Self.renderToImage(data: data, shouldRedact: true, darkMode: darkMode))
+        dispatchPrecondition(condition: .onQueue(.main))
+        let config = Config()
+        let images = Renderer.render(data: data, config: config)
 
         let client = AppDelegate.shared.client
         DispatchQueue.global().async {
-            let payloads = Panel.rlePayloads(for: [image, privacyImage])
+            let payloads = Panel.rlePayloads(for: images)
             DispatchQueue.main.sync {
                 self.fetchDidUpdate(image: payloads[0].1, privacyImage: payloads[1].1)
             }
@@ -250,176 +189,6 @@ class ViewController: UIViewController, SettingsViewControllerDelegate {
             }
         }
 
-    }
-
-    static func loadPrivacyImage() -> UIImage {
-        return (try? Config().privacyImage()) ?? Panel.blankImage()
-    }
-
-    static func renderToImage(data: [DataItemBase], shouldRedact: Bool, darkMode: Bool) -> UIImage {
-        let contentView = UIView(frame: CGRect(origin: .zero, size: Panel.size))
-        contentView.contentScaleFactor = 1.0
-
-        // Construct the contentView's contents. For now just make labels and flow them into 2 columns
-        contentView.backgroundColor = darkMode ? UIColor.black : UIColor.white
-        let foregroundColor = darkMode ? UIColor.white : UIColor.black
-        let config = Config()
-        let twoCols = config.displayTwoColumns
-        let showIcons = config.showIcons
-        let rect = contentView.frame
-        let maxy = rect.height - 10 // Leave space for status line
-        let midx = rect.width / 2
-        var x : CGFloat = 5
-        var y : CGFloat = 0
-        let colWidth = twoCols ? (rect.width / 2 - x * 2) : rect.width - x
-        let bodyFont = config.getFont(named: config.bodyFont)
-        let itemGap = CGFloat(min(10, bodyFont.textHeight / 2)) // ie 50% of the body text line height up to a max of 10px
-        var colStart = y
-        var col = 0
-        var columnItemCount = 0 // Number of items assigned to the current column
-        var divider: DividerStyle? = twoCols ? .vertical(originY: 0) : nil
-        let redactMode: RedactMode = (shouldRedact ? (config.privacyMode == .redactWords ? .redactWords : .redactLines) : .none)
-
-        for item in data {
-            
-            let flags = item.flags
-            let font = flags.contains(.header) ? config.titleFont : config.bodyFont
-            let fontDetails = Config().getFont(named: font)
-            let w = flags.contains(.spansColumns) ? rect.width : colWidth
-            let frame = CGRect(x: x, y: y, width: w, height: 0)
-            let view = UIView(frame: frame)
-            var prefix = fontDetails.supportsEmoji && showIcons ? item.iconAndPrefix : item.prefix
-            let numPrefixLines = prefix.split(separator: "\n").count
-            var textFrame = CGRect(origin: CGPoint.zero, size: frame.size)
-            var itemHeight: CGFloat = 0
-
-            if !prefix.isEmpty {
-                let prefixLabel = ViewController.getLabel(frame: textFrame,
-                                                          font: font,
-                                                          style: flags.labelStyle,
-                                                          redactMode: redactMode)
-                prefixLabel.textColor = foregroundColor
-                prefixLabel.numberOfLines = numPrefixLines
-                prefixLabel.text = prefix + " "
-                prefixLabel.sizeToFit()
-                let prefixWidth = prefixLabel.frame.width
-                if prefixWidth < frame.width / 2 {
-                    prefix = ""
-                    view.addSubview(prefixLabel)
-                    textFrame = textFrame.divided(atDistance: prefixWidth, from: .minXEdge).remainder
-                    itemHeight = prefixLabel.frame.height
-                } else {
-                    // Label too long, treat as single text entity (leave 'prefix' set)
-                    prefix = prefix + " "
-                }
-            }
-            let label = ViewController.getLabel(frame: textFrame,
-                                                font: font,
-                                                style: flags.labelStyle,
-                                                redactMode: redactMode)
-            label.numberOfLines = 1 // Temporarily while we're using it in checkFit
-
-            let text = prefix + item.getText(checkFit: { (string: String) -> Bool in
-                label.text = prefix + string
-                let size = label.sizeThatFits(textFrame.size)
-                return size.width <= textFrame.width
-            })
-            label.textColor = foregroundColor
-            if flags.contains(.warning) {
-                // Icons don't render well on the panel, use a coloured background instead
-                label.backgroundColor = UIColor.yellow
-                label.textColor = UIColor.black
-            }
-            label.numberOfLines = config.maxLines
-            label.lineBreakMode = .byTruncatingTail
-            label.text = text
-            label.sizeToFit()
-            itemHeight = max(itemHeight, label.bounds.height)
-            label.frame = CGRect(x: label.frame.minX, y: label.frame.minY, width: textFrame.width, height: label.frame.height)
-            view.frame = CGRect(origin: view.frame.origin, size: CGSize(width: view.frame.width, height: itemHeight))
-            view.addSubview(label)
-            if let subText = item.subText {
-                let subLabel = ViewController.getLabel(frame: textFrame,
-                                                       font: font,
-                                                       style: .subText,
-                                                       redactMode: redactMode)
-                subLabel.textColor = foregroundColor
-                subLabel.numberOfLines = config.maxLines
-                subLabel.text = subText
-                subLabel.sizeToFit()
-                subLabel.frame = CGRect(x: textFrame.minX, y: view.bounds.maxY + 1, width: textFrame.width, height: subLabel.frame.height)
-                view.frame = CGRect(origin: view.frame.origin, size: CGSize(width: view.frame.width, height: subLabel.frame.maxY))
-                view.addSubview(subLabel)
-            }
-            let sz = view.frame
-            // Enough space for this item?
-            let itemIsColBreak = (columnItemCount > 0 && flags.contains(.prefersEmptyColumn))
-            if (col == 0 && twoCols && (sz.height > maxy - y || itemIsColBreak)) {
-                // overflow to 2nd column
-                col += 1
-                columnItemCount = 0
-                x += midx + 5
-                y = colStart
-                view.frame = CGRect(x: x, y: y, width: sz.width, height: sz.height)
-            } else if (!twoCols && itemIsColBreak) {
-                // Leave some extra space and mark where to draw a line
-                divider = .horizontal(originY: y)
-                let c = view.center
-                view.center = CGPoint(x: c.x, y: c.y + itemGap)
-                y += itemGap
-            }
-            contentView.addSubview(view)
-
-            y = y + sz.height + itemGap
-
-            if flags.contains(.spansColumns) {
-                // Update the verticial origin of the divider and columns, and start at column 0 again.
-                divider = .vertical(originY: y)
-                colStart = y
-                columnItemCount = 0
-                col = 0
-            } else {
-                // Track the number of items in the current column.
-                columnItemCount += 1
-            }
-
-        }
-
-        // And render it into an image
-        let result = UIImage.New(rect.size, flipped: false) { context in
-            // layer.render() works when the device is locked, whereas drawHierarchy() doesn't
-            contentView.layer.render(in: context)
-
-            // Draw the dividing line.
-            if let divider = divider {
-
-                context.setStrokeColor(foregroundColor.cgColor)
-                context.beginPath()
-
-                switch divider {
-                case .vertical(let originY):
-                    context.move(to: CGPoint(x: midx, y: originY))
-                    context.addLine(to: CGPoint(x: midx, y: rect.height - Panel.statusBarHeight))
-                case .horizontal(let originY):
-                    context.move(to: CGPoint(x: x, y: originY))
-                    context.addLine(to: CGPoint(x: rect.width - x, y: originY))
-                }
-
-                context.drawPath(using: .stroke)
-            }
-        }
-        return result
-    }
-
-    private func shouldBeDark() -> Bool {
-        switch Config().darkMode {
-        case .off:
-            return false
-        case .on:
-            return true
-        case .system:
-            return traitCollection.userInterfaceStyle == UIUserInterfaceStyle.dark
-        }
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {


### PR DESCRIPTION
This change moves the render methods out of `ViewController` and into static methods on a new `Renderer` struct with a view to ultimately moving device update management out of the view controller instance. This should allow renders when the full UI stack isn't present and decouple device updates from UI, making it easier to support multiple device configurations in the future.