### PR TITLE
refactor(ios): Consolidate update generation and upload

### DIFF
--- a/ios/StatusPanel.xcodeproj/project.pbxproj
+++ b/ios/StatusPanel.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		D80380AB23E9B6D2002606C7 /* Client.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80380AA23E9B6D2002606C7 /* Client.swift */; };
+		D80380AB23E9B6D2002606C7 /* Service.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80380AA23E9B6D2002606C7 /* Service.swift */; };
 		D812523C2709875600C9D80A /* FontPickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D812523B2709875600C9D80A /* FontPickerViewController.swift */; };
 		D8166551272773AC005BDA9E /* ImageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8166550272773AC005BDA9E /* ImageTableViewCell.swift */; };
 		D816655327277407005BDA9E /* UIActivityIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D816655227277407005BDA9E /* UIActivityIndicatorView.swift */; };
@@ -125,7 +125,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		D80380AA23E9B6D2002606C7 /* Client.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Client.swift; sourceTree = "<group>"; };
+		D80380AA23E9B6D2002606C7 /* Service.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Service.swift; sourceTree = "<group>"; };
 		D812523B2709875600C9D80A /* FontPickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontPickerViewController.swift; sourceTree = "<group>"; };
 		D8166550272773AC005BDA9E /* ImageTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageTableViewCell.swift; sourceTree = "<group>"; };
 		D816655227277407005BDA9E /* UIActivityIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIActivityIndicatorView.swift; sourceTree = "<group>"; };
@@ -494,7 +494,6 @@
 				DBCA987C2143E2920084B710 /* AppDelegate.swift */,
 				DBC3B35F26F5FA4600BC5FF0 /* BitmapFontCache.swift */,
 				DB6CE1462413AB4800FF1160 /* BitmapFontLabel.swift */,
-				D80380AA23E9B6D2002606C7 /* Client.swift */,
 				D89CAF1021ABDDA200B4B314 /* Config.swift */,
 				D8DAED7126E3F3320002F388 /* Configuration.swift */,
 				D8E285AE271A45CE001738A8 /* Device.swift */,
@@ -502,6 +501,7 @@
 				D8D98E422493019A00F853CA /* NetworkProvisioner.swift */,
 				D8DCA7DB29CBEBDD002010A5 /* RedactMode.swift */,
 				D8DCA7D929CBEB42002010A5 /* Renderer.swift */,
+				D80380AA23E9B6D2002606C7 /* Service.swift */,
 				D8DAED7326E3F3930002F388 /* StatusPanelError.swift */,
 				DB5E9DA0241562ED009F3807 /* StringUtils.swift */,
 				DBCA98832143E2920084B710 /* Assets.xcassets */,
@@ -693,7 +693,7 @@
 				DB62F33E224FEA4400CA5E64 /* StationsList.swift in Sources */,
 				D81CEBBA2906B31300E4B032 /* WeatherDataSource.swift in Sources */,
 				D89CAF1621ABDDA200B4B314 /* Config.swift in Sources */,
-				D80380AB23E9B6D2002606C7 /* Client.swift in Sources */,
+				D80380AB23E9B6D2002606C7 /* Service.swift in Sources */,
 				D82D0C0621EC1E8700B1C753 /* CalendarViewController.swift in Sources */,
 				D89104852707B9A00020A2CF /* UIViewController.swift in Sources */,
 				D8C20D23271C6C1500F3F22A /* EKCalendar.swift in Sources */,

--- a/ios/StatusPanel/Config.swift
+++ b/ios/StatusPanel/Config.swift
@@ -345,7 +345,7 @@ class Config {
         }
     }
 
-    var devices: [(String, String)] {
+    @MainActor var devices: [(String, String)] {
         get {
             let ud = UserDefaults.standard
             if let oldStyle = Config.getDeviceAndKey() {
@@ -519,7 +519,8 @@ class Config {
         return "lastUploadedHash_\(deviceid)"
     }
 
-    func setLastUploadHash(for deviceid: String, to hash:String?) {
+    @MainActor func setLastUploadHash(for deviceid: String, to hash:String?) {
+        dispatchPrecondition(condition: .onQueue(.main))
         let key = Config.getLastUploadHashKey(for: deviceid)
         if let hash = hash {
             self.userDefaults.set(hash, forKey: key)
@@ -528,11 +529,12 @@ class Config {
         }
     }
 
-    func getLastUploadHash(for deviceid: String) -> String? {
+    @MainActor func getLastUploadHash(for deviceid: String) -> String? {
+        dispatchPrecondition(condition: .onQueue(.main  ))
         return self.userDefaults.string(forKey: Config.getLastUploadHashKey(for: deviceid))
     }
 
-    func clearUploadHashes() {
+    @MainActor func clearUploadHashes() {
         for (deviceid, _) in devices {
             setLastUploadHash(for: deviceid, to: nil)
         }

--- a/ios/StatusPanel/Device.swift
+++ b/ios/StatusPanel/Device.swift
@@ -20,9 +20,24 @@
 
 import Foundation
 
+import Sodium
+
 struct Device: Identifiable, Equatable {
 
     var id: String
     var publicKey: String
+
+    init(id: String, publicKey: String) {
+        self.id = id
+        self.publicKey = publicKey
+    }
+
+    // Create a new dummy device identifier.
+    init() {
+        let sodium = Sodium()
+        id = UUID().uuidString
+        let keyPair = sodium.box.keyPair()!
+        publicKey = sodium.utils.bin2base64(keyPair.publicKey, variant: .ORIGINAL)!
+    }
 
 }

--- a/ios/StatusPanel/View Controllers/SettingsViewController.swift
+++ b/ios/StatusPanel/View Controllers/SettingsViewController.swift
@@ -461,7 +461,7 @@ class SettingsViewController: UITableViewController, UIAdaptivePresentationContr
         case DevicesSection:
             let prevCount = devices.count
             if indexPath.row == (prevCount == 0 ? 1 : prevCount) {
-                let device = Device(id: "DummyDevice\(indexPath.row)", publicKey: "")
+                let device = Device()
                 devices.append((device.id, device.publicKey))
                 Config().devices = devices
                 tableView.performBatchUpdates {


### PR DESCRIPTION
This change goes some way to consolidating the process of update generation and upload with a view to moving it out into a dedicated device manager. It also starts to address thread-safety issues when accessing settings through the `Config` class and makes tentative steps towards new async code.