### PR TITLE
fix(device-python): Update the display when network connectivity returns

### DIFF
--- a/device/python/device.py
+++ b/device/python/device.py
@@ -283,12 +283,16 @@ class Device(object):
         display.show()
 
     def fetch_update(self, display):
-        if self._last_modified is not None:
-            last_modified = self.service.get_status_last_modified()
-            if last_modified == self._last_modified:
-                print("No update; skipping...")
-                return
-        images, self._last_modified = self.service.get_status()
+        try:
+            if self._last_modified is not None:
+                last_modified = self.service.get_status_last_modified()
+                if last_modified == self._last_modified:
+                    print("No update; skipping...")
+                    return
+            images, self._last_modified = self.service.get_status()
+        except:
+            self._last_modified = None  # Ensure subsequent updates clear the screen.
+            raise  # Re-raise the exception.
 
         with self._lock:
             index = 0 if self._requested_state is None else self._requested_state.index % len(images)


### PR DESCRIPTION
The change to guard updates against over updating by storing the 'last-modified' header introduced a bug whereby last modified was never cleared if the display was updated to show an error. This change clears the cached last modified field in the case of an error to ensure the next successful fetch updates the display.