### PR TITLE
refactor(ios): Use SwiftUI `Picker` for the item style selection

### DIFF
--- a/ios/StatusPanel/Data/DataSource.swift
+++ b/ios/StatusPanel/Data/DataSource.swift
@@ -60,6 +60,11 @@ extension DataSource {
 
 struct DataItemFlags: OptionSet, Codable {
 
+    enum Style {
+        case title
+        case body
+    }
+
     let rawValue: Int
 
     static let warning = DataItemFlags(rawValue: 1 << 0)
@@ -72,6 +77,23 @@ struct DataItemFlags: OptionSet, Codable {
             return .header
         }
         return .text
+    }
+
+    var style: Style {
+        get {
+            if contains(.header) {
+                return .title
+            }
+            return .body
+        }
+        set {
+            switch newValue {
+            case .title:
+                insert(.header)
+            case .body:
+                remove(.header)
+            }
+        }
     }
     
 }

--- a/ios/StatusPanel/Utilities/Localization.swift
+++ b/ios/StatusPanel/Utilities/Localization.swift
@@ -35,7 +35,7 @@ func LocalizedOffset(_ offset: Int) -> String {
     }
 }
 
-func Localize(_ darkModeConfig: Config.DarkModeConfig) -> String {
+func Localized(_ darkModeConfig: Config.DarkModeConfig) -> String {
     switch darkModeConfig {
     case .off:
         return LocalizedString("dark_mode_config_off")
@@ -46,7 +46,7 @@ func Localize(_ darkModeConfig: Config.DarkModeConfig) -> String {
     }
 }
 
-func Localize(_ style: FlagsSection.Style) -> String {
+func Localized(_ style: DataItemFlags.Style) -> String {
     switch style {
     case .title:
         return LocalizedString("flags_section_style_value_title")

--- a/ios/StatusPanel/View Controllers/DarkModeController.swift
+++ b/ios/StatusPanel/View Controllers/DarkModeController.swift
@@ -63,7 +63,7 @@ class DarkModeController : UITableViewController {
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: Self.cellReuseIdentifier, for: indexPath)
         let configValue = self.configValue(forRowAt: indexPath)
-        cell.textLabel?.text = Localize(configValue)
+        cell.textLabel?.text = Localized(configValue)
         cell.accessoryType = config.darkMode == configValue ? .checkmark : .none
         return cell
     }

--- a/ios/StatusPanel/View Controllers/SettingsViewController.swift
+++ b/ios/StatusPanel/View Controllers/SettingsViewController.swift
@@ -243,7 +243,7 @@ class SettingsViewController: UITableViewController, UIAdaptivePresentationContr
                 cell.accessoryView = control
             case 2:
                 cell.textLabel?.text = "Dark Mode"
-                cell.detailTextLabel?.text = Localize(config.darkMode)
+                cell.detailTextLabel?.text = Localized(config.darkMode)
                 cell.accessoryType = .disclosureIndicator
             case 3:
                 cell.textLabel?.text = "Maximum Lines per Item"

--- a/ios/StatusPanel/Views/FlagsSection.swift
+++ b/ios/StatusPanel/Views/FlagsSection.swift
@@ -20,36 +20,10 @@
 
 import SwiftUI
 
-extension DataItemFlags {
-
-    var style: FlagsSection.Style {
-        get {
-            if contains(.header) {
-                return .title
-            }
-            return .body
-        }
-        set {
-            switch newValue {
-            case .title:
-                insert(.header)
-            case .body:
-                remove(.header)
-            }
-        }
-    }
-
-}
-
 struct FlagsSection: View {
 
     @Binding var flags: DataItemFlags
     @State var isShowingStyle = false
-
-    enum Style {
-        case title
-        case body
-    }
 
     func prefersEmptyColumn() -> Binding<Bool> {
         Binding {
@@ -77,46 +51,12 @@ struct FlagsSection: View {
 
     var body: some View {
         Section(header: Text("Display")) {
-            NavigationLink(destination: List {
-                Button {
-                    flags.style = .title
-                    isShowingStyle = false
-                } label: {
-                    HStack {
-                        Text(Localize(Style.title))
-                        Spacer()
-                        if flags.style == .title {
-                            Image(systemName: "checkmark")
-                                .foregroundColor(.accentColor)
-                        }
-                    }
-                    .foregroundColor(.primary)
-                }
-                Button {
-                    flags.style = .body
-                    isShowingStyle = false
-                } label: {
-                    HStack {
-                        Text(Localize(Style.body))
-                        Spacer()
-                        if flags.style == .body {
-                            Image(systemName: "checkmark")
-                                .foregroundColor(.accentColor)
-                        }
-                    }
-                    .foregroundColor(.primary)
-                }
+            Picker("Style", selection: $flags.style) {
+                Text(Localized(DataItemFlags.Style.title))
+                    .tag(DataItemFlags.Style.title)
+                Text(Localized(DataItemFlags.Style.body))
+                    .tag(DataItemFlags.Style.body)
             }
-            .listStyle(GroupedListStyle())
-            .navigationTitle("Style"), isActive: $isShowingStyle) {
-                HStack {
-                    Text(LocalizedString("flags_section_style_label"))
-                    Spacer()
-                    Text(Localize(flags.style))
-                        .foregroundColor(.secondary)
-                }
-            }
-
             Toggle(LocalizedString("flags_section_prefers_empty_column_label"), isOn: prefersEmptyColumn())
             Toggle(LocalizedString("flags_section_spans_columns_label"), isOn: spansColumns())
         }


### PR DESCRIPTION
This change includes a drive-by fix to rename the localisation methods to `Localized` to match the platform conventions.