### PR TITLE
refactor(ios): Update data sources directly within `AddDataSourceController`

### DIFF
--- a/ios/StatusPanel/View Controllers/AddDataSourceController.swift
+++ b/ios/StatusPanel/View Controllers/AddDataSourceController.swift
@@ -24,7 +24,6 @@ import SwiftUI
 protocol AddDataSourceControllerDelegate: AnyObject {
 
     func addDataSourceControllerDidComplete(_ addDataSourceController: AddDataSourceController)
-    func addDataSourceControllerDidCancel(_ addDataSourceController: AddDataSourceController)
 
 }
 
@@ -56,8 +55,7 @@ class AddDataSourceController: UINavigationController {
         let view = AddDataSourceView(sourceController: dataSourceController) { dataSource in
             dispatchPrecondition(condition: .onQueue(.main))
             guard let dataSource = dataSource else {
-                self.navigationController?.dismiss(animated: true, completion: nil)
-                self.addSourceDelegate?.addDataSourceControllerDidCancel(self)
+                self.dismiss(animated: true, completion: nil)
                 return
             }
             self.didSelectDataSource(dataSource)
@@ -67,7 +65,7 @@ class AddDataSourceController: UINavigationController {
     }
 
     @objc func cancelTapped(sender: Any) {
-        addSourceDelegate?.addDataSourceControllerDidCancel(self)
+        self.dismiss(animated: true, completion: nil)
     }
 
     @objc func doneTapped(sender: Any) {

--- a/ios/StatusPanel/View Controllers/SettingsViewController.swift
+++ b/ios/StatusPanel/View Controllers/SettingsViewController.swift
@@ -422,8 +422,4 @@ extension SettingsViewController: AddDataSourceControllerDelegate {
         self.tableView.insertRows(at: [indexPath], with: .none)
     }
 
-    func addDataSourceControllerDidCancel(_ addDataSourceController: AddDataSourceController) {
-        self.navigationController?.dismiss(animated: true, completion: nil)
-    }
-
 }

--- a/ios/StatusPanel/View Controllers/SettingsViewController.swift
+++ b/ios/StatusPanel/View Controllers/SettingsViewController.swift
@@ -417,17 +417,9 @@ class SettingsViewController: UITableViewController, UIAdaptivePresentationContr
 
 extension SettingsViewController: AddDataSourceControllerDelegate {
 
-    func addDataSourceController(_ addDataSourceController: AddDataSourceController,
-                                 didCompleteWithDetails details: DataSourceInstance.Details) {
-        do {
-            try self.dataSourceController.add(details)
-            try self.dataSourceController.save()
-            let indexPath = IndexPath(row: self.dataSourceController.instances.count - 1, section: 0)
-            self.tableView.insertRows(at: [indexPath], with: .none)
-            self.navigationController?.dismiss(animated: true, completion: nil)
-        } catch {
-            present(error: error)
-        }
+    func addDataSourceControllerDidComplete(_ addDataSourceController: AddDataSourceController) {
+        let indexPath = IndexPath(row: self.dataSourceController.instances.count - 1, section: 0)
+        self.tableView.insertRows(at: [indexPath], with: .none)
     }
 
     func addDataSourceControllerDidCancel(_ addDataSourceController: AddDataSourceController) {


### PR DESCRIPTION
This change moves the work of updating the data sources into `AddDataSourceController` to allow it to be more easily reused in different places in the app. This change lays the groundwork for per-device layout management.