### PR TITLE
fix(ios): Don't show the device identifier in the devices list

### DIFF
--- a/ios/StatusPanel/Views/SettingsView.swift
+++ b/ios/StatusPanel/Views/SettingsView.swift
@@ -53,9 +53,6 @@ struct SettingsView: View {
                                 } else {
                                     Text(Localized(device.kind))
                                 }
-                                Text(device.id)
-                                    .font(.footnote)
-                                    .foregroundColor(.secondary)
                             }
                         }
                     }


### PR DESCRIPTION
The device identifier is available in the device settings view meaning we no longer need it in the main devices list.