### PR TITLE
fix(ios): Show a horizontal divider in single-column mode

### DIFF
--- a/ios/StatusPanel/AppDelegate.swift
+++ b/ios/StatusPanel/AppDelegate.swift
@@ -135,7 +135,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                                                                                                    offset: 0,
                                                                                                    activeCalendars: Set(calendars))),
                         try self.configureDataSourceInstance(type: .text,
-                                                             settings: TextDataSource.Settings(flags: [.prefersEmptyColumn],
+                                                             settings: TextDataSource.Settings(flags: [.prefersNewSection],
                                                                                                text: "Tomorrow:")),
                         try self.configureDataSourceInstance(type: .calendar,
                                                              settings: CalendarDataSource.Settings(showLocations: true,

--- a/ios/StatusPanel/Data/DataSource.swift
+++ b/ios/StatusPanel/Data/DataSource.swift
@@ -70,7 +70,7 @@ struct DataItemFlags: OptionSet, Codable {
 
     static let warning = DataItemFlags(rawValue: 1 << 0)
     static let header = DataItemFlags(rawValue: 1 << 1)
-    static let prefersEmptyColumn = DataItemFlags(rawValue: 1 << 2)
+    static let prefersNewSection = DataItemFlags(rawValue: 1 << 2)
     static let spansColumns = DataItemFlags(rawValue: 1 << 3)
 
     var labelStyle: LabelStyle {

--- a/ios/StatusPanel/PixelRenderer.swift
+++ b/ios/StatusPanel/PixelRenderer.swift
@@ -141,7 +141,7 @@ struct PixelRenderer: Renderer {
             }
             let sz = view.frame
             // Enough space for this item?
-            let itemIsColBreak = (columnItemCount > 0 && flags.contains(.prefersEmptyColumn))
+            let itemIsColBreak = (columnItemCount > 0 && flags.contains(.prefersNewSection))
             if (col == 0 && twoCols && (sz.height > maxy - y || itemIsColBreak)) {
                 // overflow to 2nd column
                 col += 1
@@ -160,7 +160,7 @@ struct PixelRenderer: Renderer {
 
             y = y + sz.height + itemGap
 
-            if flags.contains(.spansColumns) {
+            if twoCols && flags.contains(.spansColumns) {
                 // Update the verticial origin of the divider and columns, and start at column 0 again.
                 divider = .vertical(originY: y)
                 colStart = y

--- a/ios/StatusPanel/Views/FlagsSection.swift
+++ b/ios/StatusPanel/Views/FlagsSection.swift
@@ -27,12 +27,12 @@ struct FlagsSection: View {
 
     func prefersEmptyColumn() -> Binding<Bool> {
         Binding {
-            flags.contains(.prefersEmptyColumn)
+            flags.contains(.prefersNewSection)
         } set: { newValue in
             if newValue == true {
-                flags.insert(.prefersEmptyColumn)
+                flags.insert(.prefersNewSection)
             } else {
-                flags.remove(.prefersEmptyColumn)
+                flags.remove(.prefersNewSection)
             }
         }
     }
@@ -57,7 +57,7 @@ struct FlagsSection: View {
                 Text(Localized(DataItemFlags.Style.body))
                     .tag(DataItemFlags.Style.body)
             }
-            Toggle(LocalizedString("flags_section_prefers_empty_column_label"), isOn: prefersEmptyColumn())
+            Toggle(LocalizedString("flags_section_prefers_new_section_label"), isOn: prefersEmptyColumn())
             Toggle(LocalizedString("flags_section_spans_columns_label"), isOn: spansColumns())
         }
     }

--- a/ios/StatusPanel/en-GB.lproj/Localizable.strings
+++ b/ios/StatusPanel/en-GB.lproj/Localizable.strings
@@ -56,7 +56,7 @@
 "flags_section_style_label" = "Style";
 "flags_section_style_value_body" = "Body";
 "flags_section_style_value_title" = "Title";
-"flags_section_prefers_empty_column_label" = "Prefers Empty Column";
+"flags_section_prefers_new_section_label" = "Prefers New Section";
 "flags_section_spans_columns_label" = "Spans Columns";
 
 "setup_wifi_title" = "Setup Wi-Fi";

--- a/ios/StatusPanel/en.lproj/Localizable.strings
+++ b/ios/StatusPanel/en.lproj/Localizable.strings
@@ -56,7 +56,7 @@
 "flags_section_style_label" = "Style";
 "flags_section_style_value_body" = "Body";
 "flags_section_style_value_title" = "Title";
-"flags_section_prefers_empty_column_label" = "Prefers Empty Column";
+"flags_section_prefers_new_section_label" = "Prefers New Section";
 "flags_section_spans_columns_label" = "Spans Columns";
 
 "setup_wifi_title" = "Setup Wi-Fi";


### PR DESCRIPTION
We were incorrectly inserting a vertical divider whenever we saw the 'spans columns' flag _even_ if we were in single-column mode. This change fixes that bug and renames the 'Prefers New Column' option to 'Prefers New Section' to acknowledge that it will add a divider in both single- and two-column mode.