### PR TITLE
fix(ios): Disable 'Add From Clipboard' in release builds

### DIFF
--- a/ios/StatusPanel/Views/IntroductionView.swift
+++ b/ios/StatusPanel/Views/IntroductionView.swift
@@ -62,6 +62,7 @@ struct IntroductionView: View {
                         .centerContent()
                 }
                 .buttonStyle(.bordered)
+#if DEBUG
                 Button {
                     dismiss()
                     applicationModel.addFromClipboard()
@@ -70,6 +71,7 @@ struct IntroductionView: View {
                         .centerContent()
                 }
                 .buttonStyle(.bordered)
+#endif
             }
             .controlSize(.large)
             .padding()
@@ -82,7 +84,7 @@ struct IntroductionView: View {
         .navigationTitle("StatusPanel")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
-
+            
             // Don't allow the view to be dismissed if there are no devices.
             if !applicationModel.deviceModels.isEmpty {
                 ToolbarItem(placement: .navigationBarLeading) {


### PR DESCRIPTION
This is a development feature and is unnecessarily confusing for regular users.