### PR TITLE
fix(ios): Don't show alert when adding new devices

### DIFF
--- a/ios/StatusPanel/AppDelegate.swift
+++ b/ios/StatusPanel/AppDelegate.swift
@@ -111,7 +111,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let eventStore = EKEventStore()
         eventStore.requestAccess(to: EKEntityType.event) { granted, error in
             DispatchQueue.main.async {
-
                 do {
                     let calendars = eventStore.allCalendars().map { $0.calendarIdentifier }
                     var settings = device.defaultSettings()
@@ -123,13 +122,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                     return
                 }
                 self.config.devices.insert(device)
-
-                let alert = UIAlertController(title: "Device added",
-                                              message: "Device \(device.id) has been added.",
-                                              preferredStyle: .alert)
-                alert.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: "Default action"),
-                                              style: .default))
-                self.window?.rootViewController?.present(alert, animated: true)
             }
         }
     }


### PR DESCRIPTION
This was much more important when the device list wasn't part of the main UI. The experience will be improved further when we address https://github.com/inseven/statuspanel/issues/576.