### PR TITLE
feat(ios): Export preview images

### DIFF
--- a/ios/StatusPanel.xcodeproj/project.pbxproj
+++ b/ios/StatusPanel.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		D8C20D23271C6C1500F3F22A /* EKCalendar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C20D22271C6C1500F3F22A /* EKCalendar.swift */; };
 		D8C20D25271C7A2000F3F22A /* CalendarSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C20D24271C7A2000F3F22A /* CalendarSettingsView.swift */; };
 		D8C20D2B271CC1E600F3F22A /* FontLabelTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C20D2A271CC1E600F3F22A /* FontLabelTableViewCell.swift */; };
+		D8CBE83D2A091A1100631D9C /* DataView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8CBE83C2A091A1100631D9C /* DataView.swift */; };
 		D8CC37B12717887A00938C5D /* Panel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8CC37B02717887A00938C5D /* Panel.swift */; };
 		D8CD32D32471D0AA00D82722 /* ExternalAccessory.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8CD32D22471D0AA00D82722 /* ExternalAccessory.framework */; };
 		D8CE02CA2A0025BB00D32A78 /* DataSourceInstanceRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8CE02C92A0025BB00D32A78 /* DataSourceInstanceRow.swift */; };
@@ -203,6 +204,7 @@
 		D8C20D22271C6C1500F3F22A /* EKCalendar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EKCalendar.swift; sourceTree = "<group>"; };
 		D8C20D24271C7A2000F3F22A /* CalendarSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarSettingsView.swift; sourceTree = "<group>"; };
 		D8C20D2A271CC1E600F3F22A /* FontLabelTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontLabelTableViewCell.swift; sourceTree = "<group>"; };
+		D8CBE83C2A091A1100631D9C /* DataView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataView.swift; sourceTree = "<group>"; };
 		D8CC37B02717887A00938C5D /* Panel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panel.swift; sourceTree = "<group>"; };
 		D8CD32D22471D0AA00D82722 /* ExternalAccessory.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ExternalAccessory.framework; path = System/Library/Frameworks/ExternalAccessory.framework; sourceTree = SDKROOT; };
 		D8CE02C92A0025BB00D32A78 /* DataSourceInstanceRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataSourceInstanceRow.swift; sourceTree = "<group>"; };
@@ -332,11 +334,12 @@
 		D81DA7BE2712952D0052D32C /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				D8CBE83C2A091A1100631D9C /* DataView.swift */,
 				D8E285AC271A4547001738A8 /* ExternalOperation.swift */,
 				DB51C2E221749A2A00F016DB /* JSONRequest.swift */,
 				D81DA7BF2712953D0052D32C /* Localization.swift */,
-				D8CC37B02717887A00938C5D /* Panel.swift */,
 				D8EBFCC92720A6F8000E120F /* Network.swift */,
+				D8CC37B02717887A00938C5D /* Panel.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -741,6 +744,7 @@
 				D866E9D62A07BE02004B47D7 /* DataItem.swift in Sources */,
 				DB62F335224FB47A00CA5E64 /* Station.swift in Sources */,
 				DB62F33C224FCEBA00CA5E64 /* NationalRailSettingsController.swift in Sources */,
+				D8CBE83D2A091A1100631D9C /* DataView.swift in Sources */,
 				D8DAED7726E3F3D40002F388 /* Bundle.swift in Sources */,
 				D8A9B1462A04395400D306F8 /* AddDeviceView.swift in Sources */,
 				D8EBFCC8272099B0000E120F /* TextFieldTableViewCell.swift in Sources */,

--- a/ios/StatusPanel/Config.swift
+++ b/ios/StatusPanel/Config.swift
@@ -51,7 +51,7 @@ class Config: ObservableObject {
         case dataSources
         case settings(UUID)
         case deviceSettings(String)
-        case showDebugInformation
+        case showDeveloperTools
 
         static let settingsPrefix = "Settings-"
         static let deviceSettingsPrefix = "DeviceSettings-"
@@ -121,8 +121,8 @@ class Config: ObservableObject {
                 return "Settings-\(uuid.uuidString)"
             case .deviceSettings(let deviceId):
                 return "Settings-\(deviceId)"
-            case .showDebugInformation:
-                return "showDebugInformation"
+            case .showDeveloperTools:
+                return "showDeveloperTools"
             }
         }
     }
@@ -132,7 +132,7 @@ class Config: ObservableObject {
     @MainActor init() {
         devices = Self.loadDevices()
         lastBackgroundUpdate = object(for: .lastBackgroundUpdate) as? Date
-        showDebugInformation = bool(for: .showDebugInformation)
+        showDeveloperTools = bool(for: .showDeveloperTools)
     }
 
     private func object(for key: Key) -> Any? {
@@ -281,9 +281,9 @@ class Config: ObservableObject {
         }
     }
 
-    @MainActor @Published var showDebugInformation: Bool = false {
+    @MainActor @Published var showDeveloperTools: Bool = false {
         didSet {
-            set(showDebugInformation, for: .showDebugInformation)
+            set(showDeveloperTools, for: .showDeveloperTools)
         }
     }
 

--- a/ios/StatusPanel/Extensions/UIImage.swift
+++ b/ios/StatusPanel/Extensions/UIImage.swift
@@ -18,39 +18,19 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+import SwiftUI
 import UIKit
 
-class DataView {
+extension UIImage: Transferable {
 
-    let pointer: UnsafeMutableRawPointer
-    let bytesPerPixel: Int
-    let height: Int
-    let width: Int
-
-    init(pointer: UnsafeMutableRawPointer, bytesPerPixel: Int, width: Int, height: Int) {
-        self.pointer = pointer
-        self.bytesPerPixel = bytesPerPixel
-        self.width = width
-        self.height = height
-    }
-
-    func map(transform: (UInt8, UInt8, UInt8) -> (UInt8, UInt8, UInt8)) {
-        for index in 0 ..< width * height {
-            let offset = index * bytesPerPixel
-            let red = pointer.load(fromByteOffset: offset, as: UInt8.self)
-            let green = pointer.load(fromByteOffset: offset + 1, as: UInt8.self)
-            let blue = pointer.load(fromByteOffset: offset + 2, as: UInt8.self)
-
-            let (newRed, newGreen, newBlue) = transform(red, green, blue)
-            pointer.storeBytes(of: newRed, toByteOffset: offset, as: UInt8.self)
-            pointer.storeBytes(of: newGreen, toByteOffset: offset + 1, as: UInt8.self)
-            pointer.storeBytes(of: newBlue, toByteOffset: offset + 2, as: UInt8.self)
+    public static var transferRepresentation: some TransferRepresentation {
+        DataRepresentation(exportedContentType: .png) { image in
+            guard let data = image.pngData() else {
+                throw StatusPanelError.invalidImage
+            }
+            return data
         }
     }
-
-}
-
-extension UIImage {
 
     static func blankImage(size: CGSize, scale: CGFloat) -> UIImage {
         let format = UIGraphicsImageRendererFormat()

--- a/ios/StatusPanel/Utilities/DataView.swift
+++ b/ios/StatusPanel/Utilities/DataView.swift
@@ -1,0 +1,51 @@
+// Copyright (c) 2018-2023 Jason Morley, Tom Sutcliffe
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import UIKit
+
+class DataView {
+
+    let pointer: UnsafeMutableRawPointer
+    let bytesPerPixel: Int
+    let height: Int
+    let width: Int
+
+    init(pointer: UnsafeMutableRawPointer, bytesPerPixel: Int, width: Int, height: Int) {
+        self.pointer = pointer
+        self.bytesPerPixel = bytesPerPixel
+        self.width = width
+        self.height = height
+    }
+
+    func map(transform: (UInt8, UInt8, UInt8) -> (UInt8, UInt8, UInt8)) {
+        for index in 0 ..< width * height {
+            let offset = index * bytesPerPixel
+            let red = pointer.load(fromByteOffset: offset, as: UInt8.self)
+            let green = pointer.load(fromByteOffset: offset + 1, as: UInt8.self)
+            let blue = pointer.load(fromByteOffset: offset + 2, as: UInt8.self)
+
+            let (newRed, newGreen, newBlue) = transform(red, green, blue)
+            pointer.storeBytes(of: newRed, toByteOffset: offset, as: UInt8.self)
+            pointer.storeBytes(of: newGreen, toByteOffset: offset + 1, as: UInt8.self)
+            pointer.storeBytes(of: newBlue, toByteOffset: offset + 2, as: UInt8.self)
+        }
+    }
+
+}

--- a/ios/StatusPanel/Views/AddDeviceView.swift
+++ b/ios/StatusPanel/Views/AddDeviceView.swift
@@ -58,6 +58,7 @@ struct AddDeviceView: View {
 
     @Environment(\.dismiss) var dismiss
 
+    var config: Config
     var applicationModel: ApplicationModel
 
     @StateObject var model = Model()
@@ -65,7 +66,7 @@ struct AddDeviceView: View {
 
     var body: some View {
         NavigationStack(path: $pages) {
-            IntroductionView(applicationModel: applicationModel) {
+            IntroductionView(config: config, applicationModel: applicationModel) {
                 pages.append(.scan)
             } onAddDemoDevice: {
                 pages.append(.demoDevice)

--- a/ios/StatusPanel/Views/ContentView.swift
+++ b/ios/StatusPanel/Views/ContentView.swift
@@ -74,7 +74,7 @@ struct ContentView: View {
                 case .settings:
                     SettingsView(config: config, dataSourceController: dataSourceController)
                 case .add:
-                    AddDeviceView(applicationModel: applicationModel)
+                    AddDeviceView(config: config, applicationModel: applicationModel)
                 }
             }
         } detail: {

--- a/ios/StatusPanel/Views/DeviceDetailView.swift
+++ b/ios/StatusPanel/Views/DeviceDetailView.swift
@@ -116,8 +116,8 @@ struct DeviceDetailView: View {
             }
             if config.showDeveloperTools {
                 Section {
-                    LabeledContent("Type", value: deviceModel.device.kind.description)
                     LabeledContent("Identifier", value: deviceModel.device.id)
+                    LabeledContent("Type", value: deviceModel.device.kind.description)
                     LabeledContent("Size") {
                         let size = deviceModel.device.size
                         Text(String(format: "%.0f x %.0f", size.width, size.height))

--- a/ios/StatusPanel/Views/DeviceDetailView.swift
+++ b/ios/StatusPanel/Views/DeviceDetailView.swift
@@ -123,13 +123,11 @@ struct DeviceDetailView: View {
                         Text(String(format: "%.0f x %.0f", size.width, size.height))
                     }
                 }
-                if let uiImage = deviceModel.images.first {
-                    Section {
-                        ShareLink(items: deviceModel.images) { image in
-                            SharePreview(deviceModel.name, image: Image(uiImage: uiImage))
-                        } label: {
-                            Text("Share Previews")
-                        }
+                Section {
+                    ShareLink(items: deviceModel.images) { image in
+                        SharePreview(deviceModel.name, image: Image(uiImage: uiImage))
+                    } label: {
+                        Text("Share Previews")
                     }
                 }
             }

--- a/ios/StatusPanel/Views/DeviceDetailView.swift
+++ b/ios/StatusPanel/Views/DeviceDetailView.swift
@@ -125,7 +125,7 @@ struct DeviceDetailView: View {
                 }
                 Section {
                     ShareLink(items: deviceModel.images) { image in
-                        SharePreview(deviceModel.name, image: Image(uiImage: uiImage))
+                        SharePreview(deviceModel.name, image: Image(uiImage: image))
                     } label: {
                         Text("Share Previews")
                     }

--- a/ios/StatusPanel/Views/DeviceDetailView.swift
+++ b/ios/StatusPanel/Views/DeviceDetailView.swift
@@ -114,10 +114,23 @@ struct DeviceDetailView: View {
                     sheet = .settings
                 }
             }
-            if config.showDebugInformation {
+            if config.showDeveloperTools {
                 Section {
                     LabeledContent("Type", value: deviceModel.device.kind.description)
                     LabeledContent("Identifier", value: deviceModel.device.id)
+                    LabeledContent("Size") {
+                        let size = deviceModel.device.size
+                        Text(String(format: "%.0f x %.0f", size.width, size.height))
+                    }
+                }
+                if let uiImage = deviceModel.images.first {
+                    Section {
+                        ShareLink(items: deviceModel.images) { image in
+                            SharePreview(deviceModel.name, image: Image(uiImage: uiImage))
+                        } label: {
+                            Text("Share Previews")
+                        }
+                    }
                 }
             }
             Section {

--- a/ios/StatusPanel/Views/IntroductionView.swift
+++ b/ios/StatusPanel/Views/IntroductionView.swift
@@ -24,6 +24,7 @@ struct IntroductionView: View {
 
     @Environment(\.dismiss) var dismiss
 
+    @ObservedObject var config: Config
     @ObservedObject var applicationModel: ApplicationModel
 
     let onScanQRCode: () -> Void
@@ -31,7 +32,11 @@ struct IntroductionView: View {
 
     @State var scanQRCode: Bool = false
 
-    init(applicationModel: ApplicationModel, completion: @escaping () -> Void, onAddDemoDevice: @escaping () -> Void) {
+    init(config: Config,
+         applicationModel: ApplicationModel,
+         completion: @escaping () -> Void,
+         onAddDemoDevice: @escaping () -> Void) {
+        self.config = config
         self.applicationModel = applicationModel
         self.onScanQRCode = completion
         self.onAddDemoDevice = onAddDemoDevice
@@ -63,16 +68,16 @@ struct IntroductionView: View {
                         .centerContent()
                 }
                 .buttonStyle(.bordered)
-#if DEBUG
-                Button {
-                    dismiss()
-                    applicationModel.addFromClipboard()
-                } label: {
-                    Text("Add From Clipboard")
-                        .centerContent()
+                if config.showDeveloperTools {
+                    Button {
+                        dismiss()
+                        applicationModel.addFromClipboard()
+                    } label: {
+                        Text("Add From Clipboard")
+                            .centerContent()
+                    }
+                    .buttonStyle(.bordered)
                 }
-                .buttonStyle(.bordered)
-#endif
             }
             .controlSize(.large)
             .padding()

--- a/ios/StatusPanel/Views/SettingsView.swift
+++ b/ios/StatusPanel/Views/SettingsView.swift
@@ -48,8 +48,8 @@ struct SettingsView: View {
                         }
                     }
                 }
-                Section("Debug") {
-                    Toggle("Show Debug Information", isOn: $config.showDebugInformation)
+                Section("Developer") {
+                    Toggle("Show Developer Tools", isOn: $config.showDeveloperTools)
                 }
                 Button("About StatusPanel...") {
                     sheet = .about


### PR DESCRIPTION
This change adds the ability to export preview images using the share sheet. It also includes a small drive-by refactor that moves `DataView` into its own file, and renames 'Show Debug Information' to 'Show Developer Tools'.