### PR TITLE
feat(ios): Center, fit, or fill display mode for privacy images

### DIFF
--- a/ios/StatusPanel.xcodeproj/project.pbxproj
+++ b/ios/StatusPanel.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		D835EC982471D811003E402E /* NetworkExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D835EC972471D811003E402E /* NetworkExtension.framework */; };
 		D83672552A0947CF00778858 /* PrivacyImagePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83672542A0947CF00778858 /* PrivacyImagePicker.swift */; };
 		D83672572A094CDC00778858 /* PrivacyImageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83672562A094CDC00778858 /* PrivacyImageManager.swift */; };
+		D83672592A09870B00778858 /* ContentMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83672582A09870B00778858 /* ContentMode.swift */; };
 		D8383EBC270FB8E20007EBB7 /* DayPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8383EBB270FB8E20007EBB7 /* DayPicker.swift */; };
 		D8383EBE270FBA1B0007EBB7 /* DataSourceSettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8383EBD270FBA1B0007EBB7 /* DataSourceSettingsStore.swift */; };
 		D8383EC0270FC50A0007EBB7 /* FormatEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8383EBF270FC50A0007EBB7 /* FormatEditor.swift */; };
@@ -162,6 +163,7 @@
 		D835EC972471D811003E402E /* NetworkExtension.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NetworkExtension.framework; path = System/Library/Frameworks/NetworkExtension.framework; sourceTree = SDKROOT; };
 		D83672542A0947CF00778858 /* PrivacyImagePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyImagePicker.swift; sourceTree = "<group>"; };
 		D83672562A094CDC00778858 /* PrivacyImageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyImageManager.swift; sourceTree = "<group>"; };
+		D83672582A09870B00778858 /* ContentMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentMode.swift; sourceTree = "<group>"; };
 		D8383EBB270FB8E20007EBB7 /* DayPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayPicker.swift; sourceTree = "<group>"; };
 		D8383EBD270FBA1B0007EBB7 /* DataSourceSettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataSourceSettingsStore.swift; sourceTree = "<group>"; };
 		D8383EBF270FC50A0007EBB7 /* FormatEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormatEditor.swift; sourceTree = "<group>"; };
@@ -435,6 +437,7 @@
 				D866E9CD2A07BB5C004B47D7 /* DataSourceModel.swift */,
 				D8FD46082A03509500E5E97C /* DeviceModel.swift */,
 				D86278A72A0054A4003A9616 /* DeviceSettings.swift */,
+				D83672582A09870B00778858 /* ContentMode.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -807,6 +810,7 @@
 				D8C20D25271C7A2000F3F22A /* CalendarSettingsView.swift in Sources */,
 				D83CC5222707543E00260DC1 /* UIStoryboard.swift in Sources */,
 				DBCA98B7214518EF0084B710 /* DataSourceController.swift in Sources */,
+				D83672592A09870B00778858 /* ContentMode.swift in Sources */,
 				DB98148A270887590029BA0A /* UnicodeExtensions.swift in Sources */,
 				D8104E0529F3408100C394CC /* EKEvent.swift in Sources */,
 				D866E9D42A07BD96004B47D7 /* DataItemBase.swift in Sources */,

--- a/ios/StatusPanel/Model/ContentMode.swift
+++ b/ios/StatusPanel/Model/ContentMode.swift
@@ -1,0 +1,27 @@
+// Copyright (c) 2018-2023 Jason Morley, Tom Sutcliffe
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+
+enum ContentMode: String, Codable {
+    case fit
+    case fill
+    case center
+}

--- a/ios/StatusPanel/Model/DeviceSettings.swift
+++ b/ios/StatusPanel/Model/DeviceSettings.swift
@@ -33,6 +33,7 @@ struct DeviceSettings: Codable {
         case maxLines
         case privacyMode
         case privacyImage
+        case privacyImageContentMode
         case updateTime
         case titleFont
         case bodyFont
@@ -47,6 +48,7 @@ struct DeviceSettings: Codable {
     var maxLines: Int = 0
     var privacyMode: Config.PrivacyMode = .redactLines
     var privacyImage: String?
+    var privacyImageContentMode: ContentMode = .fill
     var updateTime: Date = Date(timeIntervalSinceReferenceDate: Self.defaultUpdateTime)
     var titleFont: String = Fonts.FontName.chiKareGo2
     var bodyFont: String =  Fonts.FontName.unifont16
@@ -86,6 +88,9 @@ struct DeviceSettings: Codable {
         if container.contains(.privacyImage) {
             privacyImage = try container.decode(String.self, forKey: .privacyImage)
         }
+        if container.contains(.privacyImageContentMode) {
+            privacyImageContentMode = try container.decode(ContentMode.self, forKey: .privacyImageContentMode)
+        }
         updateTime = Date(timeIntervalSinceReferenceDate: try container.decode(TimeInterval.self, forKey: .updateTime))
         titleFont = try container.decode(String.self, forKey: .titleFont)
         bodyFont = try container.decode(String.self, forKey: .bodyFont)
@@ -104,6 +109,7 @@ struct DeviceSettings: Codable {
         if let privacyImage {
             try container.encode(privacyImage, forKey: .privacyImage)
         }
+        try container.encode(privacyImageContentMode, forKey: .privacyImageContentMode)
         try container.encode(updateTime.timeIntervalSinceReferenceDate, forKey: .updateTime)
         try container.encode(titleFont, forKey: .titleFont)
         try container.encode(bodyFont, forKey: .bodyFont)

--- a/ios/StatusPanel/PixelRenderer.swift
+++ b/ios/StatusPanel/PixelRenderer.swift
@@ -215,13 +215,17 @@ struct PixelRenderer: Renderer {
             }
 
             if device.isFullColor {
-                if let image = privacyImage.scale(to: device.size, grayscale: false) {
+                if let image = privacyImage.scale(to: device.size,
+                                                  grayscale: false,
+                                                  contentMode: settings.privacyImageContentMode) {
                     return image
                 }
                 print("Failed to scale privacy image.")
                 return device.blankImage()
             } else {
-                if let image = Panel.privacyImage(from: privacyImage, size: device.size) {
+                if let image = Panel.privacyImage(from: privacyImage,
+                                                  size: device.size,
+                                                  contentMode: settings.privacyImageContentMode) {
                     return image
                 }
                 print("Failed to generate privacy image.")

--- a/ios/StatusPanel/Utilities/Panel.swift
+++ b/ios/StatusPanel/Utilities/Panel.swift
@@ -28,10 +28,10 @@ class Panel {
         case png
     }
 
-    static func privacyImage(from image: UIImage, size: CGSize) -> UIImage? {
+    static func privacyImage(from image: UIImage, size: CGSize, contentMode: ContentMode) -> UIImage? {
         guard let source = image
             .normalizeOrientation()?
-            .scale(to: size, grayscale: true)?
+            .scale(to: size, grayscale: true, contentMode: contentMode)?
             .atkinsonDither()
         else {
             return nil

--- a/ios/StatusPanel/Views/DeviceSettingsView.swift
+++ b/ios/StatusPanel/Views/DeviceSettingsView.swift
@@ -90,22 +90,28 @@ struct DeviceSettingsView: View {
                              font: deviceModel.deviceSettings.bodyFont,
                              color: .secondary,
                              redactMode: .redactWords)
-                        .id("redact-words-\(deviceModel.deviceSettings.bodyFont)")
+                    .id("redact-words-\(deviceModel.deviceSettings.bodyFont)")
                     .centerContent()
                 case .customImage:
-                    VStack {
-                        PrivacyImagePicker(image: $deviceModel.deviceSettings.privacyImage) {
-                            if let privacyImageURL = deviceModel.deviceSettings.privacyImageURL {
-                                AsyncImage(url: privacyImageURL) { image in
-                                    image
-                                        .resizable()
-                                        .aspectRatio(contentMode: .fit)
-                                } placeholder: {
-                                    ProgressView()
-                                }
-                            } else {
-                                Text("Choose Image")
+                    Picker("Display", selection: $deviceModel.deviceSettings.privacyImageContentMode) {
+                        Text("Fill Screen")
+                            .tag(ContentMode.fill)
+                        Text("Fit to Screen")
+                            .tag(ContentMode.fit)
+                        Text("Center")
+                            .tag(ContentMode.center)
+                    }
+                    PrivacyImagePicker(image: $deviceModel.deviceSettings.privacyImage) {
+                        if let privacyImageURL = deviceModel.deviceSettings.privacyImageURL {
+                            AsyncImage(url: privacyImageURL) { image in
+                                image
+                                    .resizable()
+                                    .aspectRatio(contentMode: .fit)
+                            } placeholder: {
+                                ProgressView()
                             }
+                        } else {
+                            Text("Choose Image")
                         }
                     }
                 }


### PR DESCRIPTION
This change includes a drive-by fix to ensure the privacy image is always centered whatever the display mode.