### PR TITLE
fix(service): Fix image clean up when removing Debian packages

### DIFF
--- a/service/ansible/ansible.cfg
+++ b/service/ansible/ansible.cfg
@@ -2,3 +2,4 @@
 
 hostfile = hosts
 host_key_checking = False
+nocows = True

--- a/service/package/prerm
+++ b/service/package/prerm
@@ -5,4 +5,4 @@ systemctl stop statuspanel-service.service
 systemctl disable statuspanel-service.service
 
 # Remove the image.
-docker rm $IMAGE_SHA
+docker image rm $IMAGE_SHA


### PR DESCRIPTION
This includes a drive-by fix to disable cowboy in the Ansible configuration.