### PR TITLE
fix(service): Small copy tweaks to the status page

### DIFF
--- a/service/web/src/static/index.html
+++ b/service/web/src/static/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <title>StatusPanel API</title>
+        <title>StatusPanel Service</title>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -75,7 +75,7 @@
     </head>
     <body>
         <div class="content">
-            <h1>StatusPanel API</h1>
+            <h1>StatusPanel Service</h1>
             <ul class="widgets">
                 <li>
                     <table>
@@ -102,7 +102,7 @@
                 </li>
             </ul>
             <div class="footer">
-                <p>&copy; 2018-2023 <a href="https://jbmorley.co.uk" target="_blank">Jason Morley</a>, <a href="https://github.com/tomsci" target="_blank">Tom Sutcliffe</a></p>
+                <p>Copyright &copy; 2018-2023 <a href="https://jbmorley.co.uk" target="_blank">Jason Morley</a>, <a href="https://github.com/tomsci" target="_blank">Tom Sutcliffe</a></p>
                 <p><a href="https://statuspanel.io" target="_blank">https://statuspanel.io</a></p>
                 <p>Published by <a href="https://inseven.co.uk" target="_blank">InSeven Limited</a></p>
             </div>


### PR DESCRIPTION
Update the title to 'StatusPanel Service', and add an explicit 'Copyright' to the copyright string.