### PR TITLE
ci(ios): Build on GitHub Actions builders and self-hosted builders

### DIFF
--- a/.github/workflows/build-app.yaml
+++ b/.github/workflows/build-app.yaml
@@ -13,7 +13,10 @@ jobs:
   build-app:
 
     name: build-app
-    runs-on: macos-ventura
+    # runs-on: macos-ventura
+    strategy:
+      matrix:
+        os: [macos-ventura, macos-13]
 
     steps:
 

--- a/.github/workflows/build-app.yaml
+++ b/.github/workflows/build-app.yaml
@@ -17,6 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-ventura, macos-13]
+      runs-on: ${{ matrix.os }}
 
     steps:
 

--- a/.github/workflows/build-app.yaml
+++ b/.github/workflows/build-app.yaml
@@ -13,11 +13,10 @@ jobs:
   build-app:
 
     name: build-app
-    # runs-on: macos-ventura
     strategy:
       matrix:
         os: [macos-ventura, macos-13]
-      runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
 
     steps:
 

--- a/.github/workflows/build-app.yaml
+++ b/.github/workflows/build-app.yaml
@@ -15,7 +15,7 @@ jobs:
     name: build-app
     strategy:
       matrix:
-        os: [macos-ventura, macos-13]
+        os: [inseven-macos-13, macos-13]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -23,8 +23,14 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
       with:
-        submodules: recursive
         fetch-depth: 0
+
+    - name: Checkout required submodules
+      run: |
+        git submodule update --init --recursive --depth 1 ios/diligence
+        git submodule update --init --recursive --depth 1 ios/swift-sodium
+        git submodule update --init --recursive --depth 1 scripts/build-tools
+        git submodule update --init --recursive --depth 1 scripts/changes
 
     - uses: actions/setup-node@v3
       with:

--- a/.github/workflows/build-app.yaml
+++ b/.github/workflows/build-app.yaml
@@ -53,7 +53,7 @@ jobs:
 
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-        RELEASE: ${{ github.ref == 'refs/heads/main' }}
+        RELEASE: ${{ github.ref == 'refs/heads/main' && matrix.os == 'macos-13' }}
 
       run: |
         scripts/build.sh

--- a/.gitmodules
+++ b/.gitmodules
@@ -24,7 +24,7 @@
 	url = https://github.com/tomsci/nodemcu-firmware.git
 [submodule "ios/diligence"]
 	path = ios/diligence
-	url = git@github.com:inseven/diligence.git
+	url = https://github.com/inseven/diligence.git
 [submodule "simulator/DataStream"]
 	path = simulator/macos/DataStream
 	url = git@github.com:jbmorley/DataStream.git


### PR DESCRIPTION
This change updates the iOS app GitHub Actions workflow to a matrix build in anticipation of a new macOS release following WWDC 2023. We'll use the GitHub-provided macOS 13 runner for release allowing us to transition the self-hosted runner to macOS [presumably] 14.