### PR TITLE
fix(firmware): Don't require Inky to be attached in order to init

### DIFF
--- a/device/nodemcu/README.markdown
+++ b/device/nodemcu/README.markdown
@@ -189,7 +189,7 @@ Note, this configuration is now the default, because USB CDC does not (currently
 
 #### esp32s3
 
-The esp32s3 supports "USB JTAG" which offers a dedicated USB serial port. However the device will not boot until something connects to the serial port meaning this configuration is useless when using the device when not connected to a computer. Therefore, the default sdkconfig sets the primary console to be on the RX and TX pins, with debug output being mirrored to the USB serial port (but not supporting input on that port). This configuration does allow the device to boot with nothing connected to the USB port.
+The esp32s3 supports "USB JTAG" which offers a dedicated USB serial port. However the device will not boot until something connects to the serial port meaning this configuration is useless when using the device when not connected to a computer. Therefore, the default sdkconfig sets the primary console to be on the RX and TX pins, with debug output being mirrored to the USB serial port (but not supporting input on that port). This default configuration does allow the device to boot with nothing connected to the USB port, while also being able to get output out of the USB port and flash it. Just not to input commands over USB when in non-auto mode.
 
 To revert to having the console on USB serial (eg for convenience of debugging), apply the `usbdebug.patch` diff to `sdkconfig`:
 

--- a/device/nodemcu/src/init.lua
+++ b/device/nodemcu/src/init.lua
@@ -279,15 +279,19 @@ function init()
         elseif chiptype == "esp32s3" then
             sda = 3
             scl = 4
+            -- Don't bother doing detection if we know it's an S3
+            _isInky = true
         else
             error("Unsupported chip type "..chiptype)
         end
         local inky_eeprom_addr = 0x50
         -- print("i2c_setup")
         i2c_setup(sda, scl)
-        -- print("i2c_setup done")
-        _isInky = i2c_ping(inky_eeprom_addr)
-        i2c_stop()
+        if not _isInky then
+            -- print("i2c_setup done")
+            _isInky = i2c_ping(inky_eeprom_addr)
+            i2c_stop()
+        end
 
         if isInky() then
             print("Configuring as Inky "..chiptype) 

--- a/device/nodemcu/src/main.lua
+++ b/device/nodemcu/src/main.lua
@@ -352,6 +352,7 @@ if NeoPixelPin ~= nil then
         decoding = neorgb(255, 0, 255), -- purple
         drawing = neorgb(255, 0, 255), -- purple
         unpairing = neorgb(255, 0, 0), -- red
+        white = neorgb(255, 255, 255), -- for testing
     }
     function setNeoPixelValue(val)
         gpio.write(NeoPixelPowerPin, 1)


### PR DESCRIPTION
On the S3 anyway, there's no need to do an initial ping, and not doing it means you can boot the board (to non-auto mode) without needing the screen to be connected.