### PR TITLE
ci: Update the builds for Xcode 15

### DIFF
--- a/.github/workflows/build-app.yaml
+++ b/.github/workflows/build-app.yaml
@@ -15,7 +15,11 @@ jobs:
     name: build-app
     strategy:
       matrix:
-        os: [inseven-macos-13, macos-13]
+        include:
+          - os: inseven-macos-13
+            simulator: iPhone 15 Pro
+          - os: macos-13
+            simulator: iPhone 14 Pro
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/build-app.yaml
+++ b/.github/workflows/build-app.yaml
@@ -46,6 +46,8 @@ jobs:
     - name: Build, test, and release
       env:
 
+        IPHONE_SIMULATOR: ${{ matrix.simulator }}
+
         APPLE_DISTRIBUTION_CERTIFICATE_BASE64: ${{ secrets.APPLE_DISTRIBUTION_CERTIFICATE_BASE64 }}
         APPLE_DISTRIBUTION_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_DISTRIBUTION_CERTIFICATE_PASSWORD }}
 

--- a/ios/ExportOptions.plist
+++ b/ios/ExportOptions.plist
@@ -2,23 +2,25 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>destination</key>
+	<string>export</string>
+	<key>manageAppVersionAndBuildNumber</key>
+	<false/>
+	<key>method</key>
+	<string>app-store</string>
 	<key>provisioningProfiles</key>
 	<dict>
 		<key>uk.co.inseven.status-panel</key>
 		<string>StatusPanel App Store Profile</string>
 	</dict>
-	<key>destination</key>
-	<string>export</string>
-	<key>method</key>
-	<string>app-store</string>
+	<key>signingCertificate</key>
+	<string>2AEA1234843D262A1F540E2F27DCC258932B0F57</string>
 	<key>signingStyle</key>
-	<string>automatic</string>
+	<string>manual</string>
 	<key>stripSwiftSymbols</key>
 	<true/>
 	<key>teamID</key>
 	<string>S4WXAUZQEV</string>
-	<key>uploadBitcode</key>
-	<false/>
 	<key>uploadSymbols</key>
 	<true/>
 </dict>

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -62,7 +62,7 @@ done
 
 # iPhone to be used for smoke test builds and tests.
 # This doesn't specify the OS version to allow the build script to recover from minor build changes.
-IPHONE_DESTINATION="platform=iOS Simulator,name=iPhone 14 Pro"
+IPHONE_DESTINATION="platform=iOS Simulator,name=iPhone 15 Pro"
 
 # Generate a random string to secure the local keychain.
 export TEMPORARY_KEYCHAIN_PASSWORD=`openssl rand -base64 14`

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -62,7 +62,7 @@ done
 
 # iPhone to be used for smoke test builds and tests.
 # This doesn't specify the OS version to allow the build script to recover from minor build changes.
-IPHONE_DESTINATION="platform=iOS Simulator,name=iPhone 15 Pro"
+IPHONE_DESTINATION="platform=iOS Simulator,name=$IPHONE_SIMULATOR"
 
 # Generate a random string to secure the local keychain.
 export TEMPORARY_KEYCHAIN_PASSWORD=`openssl rand -base64 14`


### PR DESCRIPTION
This change updates the tests to use the iPhone 15 Pro simulator and adopts async/await for the inner upload implementation to address an error-turned-warning when calling `MainActor` isolated code from the main queue.