### PR TITLE
feat(ios): Colorise characters whose unicode names include colors we can represent

### DIFF
--- a/ios/StatusPanel/BitmapFontLabel.swift
+++ b/ios/StatusPanel/BitmapFontLabel.swift
@@ -21,10 +21,32 @@
 import UIKit
 import CoreImage
 
+fileprivate func colorForCharacter(_ char: Character) -> UIColor? {
+    guard let charName = char.unicodeScalars.first!.properties.name else {
+        return nil
+    }
+    let words = charName.split(separator: " ")
+    if words.contains("GREEN") {
+        return UIColor.green
+    } else if words.contains("RED") {
+        return UIColor.red
+    } else if words.contains("BLUE") {
+        return UIColor.blue
+    } else if words.contains("ORANGE") {
+        return UIColor.orange
+    } else if words.contains("YELLOW") {
+        return UIColor.yellow
+    }
+
+    return nil
+}
+
 class BitmapFontLabel: UILabel {
+
     var style: BitmapFontCache.Style
     let maxFullSizeLines = Int.max
     var redactMode: RedactMode
+    var colorHint = ColorHint.monochrome
 
     init(frame: CGRect, bitmapFont: Fonts.BitmapInfo, scale: Int = 1, redactMode: RedactMode = .none) {
         self.style = BitmapFontCache.Style(font: bitmapFont, scale: scale, darkMode: false)
@@ -165,6 +187,9 @@ class BitmapFontLabel: UILabel {
                 } else {
                     ctx.saveGState()
                     ctx.clip(to: rect, mask: chImg)
+                    if colorHint == .inkyPalette, let charColor = colorForCharacter(ch) {
+                        ctx.setFillColor(charColor.cgColor)
+                    }
                     ctx.fill(rect)
                     ctx.restoreGState()
                 }

--- a/ios/StatusPanel/Controls/FontLabelTableViewCell.swift
+++ b/ios/StatusPanel/Controls/FontLabelTableViewCell.swift
@@ -26,7 +26,7 @@ class FontLabelTableViewCell: UITableViewCell {
     let redactMode: RedactMode
 
     lazy var label: UILabel = {
-        let label = UILabel.getLabel(frame: .zero, font: labelFont.configName, style: .text, redactMode: redactMode)
+        let label = UILabel.getLabel(frame: .zero, font: labelFont.configName, style: .text, colorHint: .monochrome, redactMode: redactMode)
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()

--- a/ios/StatusPanel/Device.swift
+++ b/ios/StatusPanel/Device.swift
@@ -28,7 +28,7 @@ struct Device: Identifiable, Equatable, Hashable {
     enum Kind: String, CaseIterable, Identifiable {
 
         static let demoDevices: [Kind] = [
-            .pimoroniInkyImpression4_rle,
+            .pimoroniInkyImpression4,
             .einkV1,
             .featherTft
         ]

--- a/ios/StatusPanel/Extensions/UILabel.swift
+++ b/ios/StatusPanel/Extensions/UILabel.swift
@@ -22,17 +22,27 @@ import UIKit
 
 extension UILabel {
 
+    enum ColorHint {
+        case monochrome
+        case inkyPalette
+    }
+
     static func getLabel(frame: CGRect,
                          font fontName: String,
                          style: LabelStyle,
+                         colorHint: ColorHint,
                          redactMode: RedactMode = .none) -> UILabel {
         dispatchPrecondition(condition: .onQueue(.main))
         let font = Fonts.font(named: fontName)
         let size = (style == .header) ? font.headerSize : (style == .subText) ? font.subTextSize : font.textSize
         if let bitmapInfo = font.bitmapInfo {
-            return BitmapFontLabel(frame: frame, bitmapFont: bitmapInfo, scale: size, redactMode: redactMode)
+            let label = BitmapFontLabel(frame: frame, bitmapFont: bitmapInfo, scale: size, redactMode: redactMode)
+            label.colorHint = colorHint
+            return label
         } else if let uifont = UIFont(name: font.uifontName!, size: CGFloat(size)) {
-            return BitmapFontLabel(frame: frame, uiFont: uifont, redactMode: redactMode)
+            let label = BitmapFontLabel(frame: frame, uiFont: uifont, redactMode: redactMode)
+            label.colorHint = colorHint
+            return label
         }
 
         // Otherwise, a plain old label (this code path now only used if we fail to find a font)

--- a/ios/StatusPanel/PixelRenderer.swift
+++ b/ios/StatusPanel/PixelRenderer.swift
@@ -79,6 +79,7 @@ struct PixelRenderer: Renderer {
         var columnItemCount = 0 // Number of items assigned to the current column
         var divider: DividerStyle? = twoCols ? .vertical(originY: 0) : nil
         let redactMode: RedactMode = (redact ? (settings.privacyMode == .redactWords ? .redactWords : .redactLines) : .none)
+        let colorHint: UILabel.ColorHint = device.kind == .pimoroniInkyImpression4 ? .inkyPalette : .monochrome
 
         for item in data {
 
@@ -97,6 +98,7 @@ struct PixelRenderer: Renderer {
                 let prefixLabel = UILabel.getLabel(frame: textFrame,
                                                    font: font,
                                                    style: flags.labelStyle,
+                                                   colorHint: colorHint,
                                                    redactMode: redactMode)
                 prefixLabel.textColor = (device.isFullColor && !redact) ? (item.accentColor ?? foregroundColor) : foregroundColor
                 prefixLabel.numberOfLines = numPrefixLines
@@ -116,6 +118,7 @@ struct PixelRenderer: Renderer {
             let label = UILabel.getLabel(frame: textFrame,
                                          font: font,
                                          style: flags.labelStyle,
+                                         colorHint: colorHint,
                                          redactMode: redactMode)
             label.numberOfLines = 1 // Temporarily while we're using it in checkFit
 
@@ -145,6 +148,7 @@ struct PixelRenderer: Renderer {
                 let subLabel = UILabel.getLabel(frame: textFrame,
                                                 font: font,
                                                 style: .subText,
+                                                colorHint: colorHint,
                                                 redactMode: redactMode)
                 subLabel.textColor = foregroundColor
                 subLabel.numberOfLines = settings.maxLines

--- a/ios/StatusPanel/Views/FontView.swift
+++ b/ios/StatusPanel/Views/FontView.swift
@@ -40,7 +40,7 @@ struct FontView: UIViewRepresentable {
     }
 
     func makeUIView(context: Context) -> UILabel {
-        let label = UILabel.getLabel(frame: .zero, font: font, style: .text, redactMode: redactMode)
+        let label = UILabel.getLabel(frame: .zero, font: font, style: .text, colorHint: .monochrome, redactMode: redactMode)
         label.text = text
         label.textColor = UIColor(color)
         return label


### PR DESCRIPTION
For now, this ignores colors the inky can't handle directly, such as purple.