### PR TITLE
ci: Update the iOS workflow to automatically generate releases

### DIFF
--- a/.github/workflows/build-app.yaml
+++ b/.github/workflows/build-app.yaml
@@ -52,7 +52,7 @@ jobs:
 
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-        RELEASE: ${{ github.ref == 'refs/heads/main' && matrix.os == 'inseven-macos-14' }}
+        RELEASE: ${{ github.ref == 'refs/heads/main' }}
 
       run: |
         scripts/build.sh


### PR DESCRIPTION
I forgot to update the release check to stop checking against the matrix build name.