### PR TITLE
ci: Don't check website builds into a separate branch

### DIFF
--- a/.github/workflows/build-website.yaml
+++ b/.github/workflows/build-website.yaml
@@ -46,6 +46,15 @@ jobs:
       run: |
         scripts/build-website.sh
 
+    - name: Fix permissions
+      run: |
+        chmod -v -R +rX "_site/" | while read line; do
+          echo "::warning title=Invalid file permissions automatically fixed::$line"
+        done
+
+    - name: Upload Pages artifact
+      uses: actions/upload-pages-artifact@v2
+
     - name: Commit documentation
       uses: stefanzweifel/git-auto-commit-action@v4
       id: auto-commit

--- a/.github/workflows/build-website.yaml
+++ b/.github/workflows/build-website.yaml
@@ -55,12 +55,23 @@ jobs:
     - name: Upload Pages artifact
       uses: actions/upload-pages-artifact@v2
 
-    - name: Commit documentation
-      uses: stefanzweifel/git-auto-commit-action@v4
-      id: auto-commit
-      if: ${{ github.ref == 'refs/heads/main' }}
-      with:
-        branch: documentation
-        create_branch: true
-        push_options: --force
-        commit_message: "docs: Update release notes"
+  deploy:
+    needs: build-website
+    if: ${{ github.ref == 'refs/heads/main' }}
+
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    # Specify runner + deployment step
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2 # or the latest "vX.X.X" version tag for this action

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,16 @@
 /.local
+
 /build
+
 /device/nodemcu/.espressif/
 /device/nodemcu/build*
+
+/docs/release-notes/index.markdown
+/docs/simulator/assets
+/docs/simulator/index.md
+
 /ios/StatusPanel/configuration.json
+
 /service/build
 /service/package/statuspanel-service/DEBIAN/control
 /service/package/statuspanel-service/DEBIAN/prerm

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -33,6 +33,7 @@ github_username:  jekyll
 theme: minima
 plugins:
   - jekyll-feed
+destination: ../_site
 
 defaults:
   - values:

--- a/scripts/build-website.sh
+++ b/scripts/build-website.sh
@@ -46,3 +46,6 @@ mkdir -p "${RELEASE_NOTES_DIRECTORY}"
 changes notes --pre-release --all --released --template "$RELEASE_NOTES_TEMPLATE_PATH" > "$RELEASE_NOTES_PATH"
 
 "${SCRIPTS_DIRECTORY}/build-simulator-web.sh"
+
+cd "${WEBSITE_DIRECTORY}"
+bundle exec jekyll build

--- a/scripts/build-website.sh
+++ b/scripts/build-website.sh
@@ -47,5 +47,14 @@ changes notes --pre-release --all --released --template "$RELEASE_NOTES_TEMPLATE
 
 "${SCRIPTS_DIRECTORY}/build-simulator-web.sh"
 
+# Install the Jekyll dependencies.
+export GEM_HOME="${ROOT_DIRECTORY}/.local/ruby"
+mkdir -p "$GEM_HOME"
+export PATH="${GEM_HOME}/bin":$PATH
+gem install bundler
+cd "${WEBSITE_DIRECTORY}"
+bundle install
+
+# Build the website.
 cd "${WEBSITE_DIRECTORY}"
 bundle exec jekyll build


### PR DESCRIPTION
This changes uses GitHub actions 'new' support for custom pages builds to deploy directly rather than going via a documentation branch. This makes it much easier to git ignore intermediate website build files so we don't mistakenly check them in locally and paves the way to adding a Jekyll plugin so it can generate release notes (and perhaps even the simulator) itself.