### PR TITLE
service: Update the API page to remove InSeven from the footer

### DIFF
--- a/service/README.markdown
+++ b/service/README.markdown
@@ -24,6 +24,20 @@ Deployment is performed using an Ansible playbook located in the 'ansible' direc
 
 There are currently two environments configured: 'staging' and 'production'.
 
+## Logs
+
+View the service logs on the server:
+
+```bash
+sudo journalctl -u statuspanel-service
+```
+
+Tail the logs:
+
+```bash
+sudo journalctl -u statuspanel-service -f
+```
+
 ## Development
 
 ### Installing Dependencies

--- a/service/web/src/static/index.html
+++ b/service/web/src/static/index.html
@@ -104,7 +104,6 @@
             <div class="footer">
                 <p>Copyright &copy; 2018-2023 <a href="https://jbmorley.co.uk" target="_blank">Jason Morley</a>, <a href="https://github.com/tomsci" target="_blank">Tom Sutcliffe</a></p>
                 <p><a href="https://statuspanel.io" target="_blank">https://statuspanel.io</a></p>
-                <p>Published by <a href="https://inseven.co.uk" target="_blank">InSeven Limited</a></p>
             </div>
         </div>
     </body>


### PR DESCRIPTION
StatusPanel is no longer published by InSeven so we don't need the footer anymore.