### PR TITLE
ci: Use Python 3.10 for esp32 firmware builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -71,6 +71,9 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    - name: Install the tool dependencies
+      uses: jdx/mise-action@v2
+
     - name: Get nodemcu-firmware sha
       id: get-firmware-sha
       run: |


### PR DESCRIPTION
This change uses `.tool-versions` via mise-en-place to pin Python to 3.10.11 as required by the esp32 nodemcu firmware builds.