### PR TITLE
ci: Disable esp32 firmware builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -56,61 +56,61 @@ jobs:
       run: |
         scripts/build.sh
 
-  firmware-build:
-
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        target:
-          - esp32
-          - esp32s2
-          - esp32s3
-
-    steps:
-
-    - name: Checkout repository
-      uses: actions/checkout@v4
-
-    - name: Install the tool dependencies
-      uses: jdx/mise-action@v2
-
-    - name: Get nodemcu-firmware sha
-      id: get-firmware-sha
-      run: |
-        echo "sha=$(git rev-parse HEAD:device/nodemcu/nodemcu-firmware)" >> $GITHUB_OUTPUT
-      shell: bash
-
-    - name: Cache Espressif submodule and toolchain
-      uses: actions/cache@v4
-      with:
-        path: |
-          .git/modules/firmware/nodemcu-firmware
-          device/nodemcu/nodemcu-firmware
-          device/nodemcu/.espressif
-        key: ${{ runner.os }}-espressif-toolchain-${{ steps.get-firmware-sha.outputs.sha }}
-
-    - name: Cache NodeMCU build
-      uses: actions/cache@v4
-      with:
-        path: |
-          device/nodemcu/nodemcu-firmware/build
-        key: ${{ runner.os }}-espressif-toolchain-${{ steps.get-firmware-sha.outputs.sha }}-${{ hashFiles('device/nodemcu/', matrix.target, '/sdkconfig') }}-${{ matrix.target }}
-
-    - name: Checkout required submodules
-      run: |
-        git submodule update --init --recursive --depth 1 device/nodemcu/nodemcu-firmware esptool
-
-    - name: Build
-      run: |
-        device/nodemcu/build.sh ${{ matrix.target }}
-
-    - name: Archive the firmware
-      uses: actions/upload-artifact@v4
-      with:
-        name: firmware-${{ matrix.target }}
-        path: device/nodemcu/build-${{ matrix.target }}/firmware-${{ matrix.target }}.zip
-        if-no-files-found: error
-
+#   firmware-build:
+#
+#     runs-on: ubuntu-latest
+#     strategy:
+#       matrix:
+#         target:
+#           - esp32
+#           - esp32s2
+#           - esp32s3
+#
+#     steps:
+#
+#     - name: Checkout repository
+#       uses: actions/checkout@v4
+#
+#     - name: Install the tool dependencies
+#       uses: jdx/mise-action@v2
+#
+#     - name: Get nodemcu-firmware sha
+#       id: get-firmware-sha
+#       run: |
+#         echo "sha=$(git rev-parse HEAD:device/nodemcu/nodemcu-firmware)" >> $GITHUB_OUTPUT
+#       shell: bash
+#
+#     - name: Cache Espressif submodule and toolchain
+#       uses: actions/cache@v4
+#       with:
+#         path: |
+#           .git/modules/firmware/nodemcu-firmware
+#           device/nodemcu/nodemcu-firmware
+#           device/nodemcu/.espressif
+#         key: ${{ runner.os }}-espressif-toolchain-${{ steps.get-firmware-sha.outputs.sha }}
+#
+#     - name: Cache NodeMCU build
+#       uses: actions/cache@v4
+#       with:
+#         path: |
+#           device/nodemcu/nodemcu-firmware/build
+#         key: ${{ runner.os }}-espressif-toolchain-${{ steps.get-firmware-sha.outputs.sha }}-${{ hashFiles('device/nodemcu/', matrix.target, '/sdkconfig') }}-${{ matrix.target }}
+#
+#     - name: Checkout required submodules
+#       run: |
+#         git submodule update --init --recursive --depth 1 device/nodemcu/nodemcu-firmware esptool
+#
+#     - name: Build
+#       run: |
+#         device/nodemcu/build.sh ${{ matrix.target }}
+#
+#     - name: Archive the firmware
+#       uses: actions/upload-artifact@v4
+#       with:
+#         name: firmware-${{ matrix.target }}
+#         path: device/nodemcu/build-${{ matrix.target }}/firmware-${{ matrix.target }}.zip
+#         if-no-files-found: error
+#
 #   raspberry-pi-image-build:
 #
 #     strategy:


### PR DESCRIPTION
It looks like the version of `cmake` that now comes with Ubuntu has dropped support for the the declared format used by the esp32 `CMakeLists.txt` 🤦🏻‍♂️. This change simply disables the firmware builds as I don’t have the time to look into it at the moment.